### PR TITLE
Add top level parameter support

### DIFF
--- a/src/cci_cfg/cci_datatypes.h
+++ b/src/cci_cfg/cci_datatypes.h
@@ -61,9 +61,15 @@ CCI_OPEN_NAMESPACE_
     /// Vendor specific/other Parameter type
     other_param
   };
-  
-  /// Enumeration for convenient cci_param_typed constructor: for chose if a param gets a top-level-name
-  enum cci_top_level_name { CCI_TOP_LEVEL_NAME=0 };
+
+  /**
+   * Enumeration for convenient cci_param_typed constructor.
+   * Choose if a param gets a relative or an absolute name.
+   */
+  enum cci_name_type {
+    CCI_RELATIVE_NAME,
+    CCI_ABSOLUTE_NAME
+  };
   
   
 CCI_CLOSE_NAMESPACE_

--- a/src/cci_cfg/cci_param_typed.h
+++ b/src/cci_cfg/cci_param_typed.h
@@ -226,42 +226,17 @@ public:
 
     /**
      * Constructor with (local/hierarchical) name, default value,
-     * description and originator.
-     *
-     * @param name Name of the parameter
-     * @param default_value Default typed value of the parameter (Typed value)
-     * @param desc Description of the paramaeter
-     * @param originator Originator of the parameter
-     */
-    cci_param_typed(const std::string& name, const value_type& default_value,
-                    const std::string& desc = "",
-                    const cci_originator& originator = cci_originator());
-
-    /**
-     * Constructor with (local/hierarchical) name, default value,
-     * description and originator.
-     *
-     * @param name Name of the parameter
-     * @param default_value Default value of the parameter (CCI value)
-     * @param desc Description of the paramaeter
-     * @param originator Originator of the parameter
-     */
-    cci_param_typed(const std::string& name, const cci_value& default_value,
-                    const std::string& desc = "",
-                    const cci_originator& originator = cci_originator());
-
-    /**
-     * Constructor with (local/hierarchical) name, default value,
      * top-level name, description and originator.
      *
      * @param name Name of the parameter
      * @param default_value Default value of the parameter (Typed value)
      * @param desc Description of the paramaeter
-     * @param cci_top_level_name Either the name should be absolute or relative
+     * @param name_type Either the name should be absolute or relative
      * @param originator Originator of the parameter
      */
     cci_param_typed(const std::string& name, const value_type& default_value,
-                    cci_top_level_name, const std::string& desc = "",
+                    const std::string& desc = "",
+                    cci_name_type name_type = CCI_RELATIVE_NAME,
                     const cci_originator& originator = cci_originator());
 
     /**
@@ -271,71 +246,46 @@ public:
      * @param name Name of the parameter
      * @param default_value Default value of the parameter (CCI value)
      * @param desc Description of the paramaeter
-     * @param cci_top_level_name Either the name should be absolute or relative
+     * @param name_type Either the name should be absolute or relative
      * @param originator Originator of the parameter
      */
     cci_param_typed(const std::string& name, const cci_value& default_value,
-                    cci_top_level_name, const std::string& desc = "",
+                    const std::string& desc = "",
+                    cci_name_type name_type = CCI_RELATIVE_NAME,
                     const cci_originator& originator = cci_originator());
 
     /**
      * Constructor with (local/hierarchical) name, default value,
-     * private broker, description and originator.
+     * private broker, description, name type and originator.
      *
      * @param name Name of the parameter
      * @param default_value Default value of the parameter (Typed value)
-     * @param desc Description of the paramaeter
      * @param private_broker Associated private broker
+     * @param desc Description of the paramaeter
+     * @param name_type Either the name should be absolute or relative
      * @param originator Originator of the parameter
      */
     cci_param_typed(const std::string& name, const value_type& default_value,
-                    cci_broker_if& private_broker, const std::string& desc = "",
+                    cci_broker_if& private_broker,
+                    const std::string& desc = "",
+                    cci_name_type name_type = CCI_RELATIVE_NAME,
                     const cci_originator& originator = cci_originator());
 
     /**
      * Constructor with (local/hierarchical) name, default value,
-     * private broker, description and originator.
+     * private broker, description, name type and originator.
      *
      * @param name Name of the parameter
      * @param default_value Default value of the parameter (CCI value)
-     * @param desc Description of the paramaeter
      * @param private_broker Associated private broker
+     * @param desc Description of the paramaeter
+     * @param name_type Either the name should be absolute or relative
      * @param originator Originator of the parameter
      */
     cci_param_typed(const std::string& name, const cci_value& default_value,
-                    cci_broker_if& private_broker, const std::string& desc = "",
-                    const cci_originator& originator = cci_originator());
-
-    /**
-     * Constructor with (local/hierarchical) name, default value,
-     * private broker, top-level name, description and originator.
-     *
-     * @param name Name of the parameter
-     * @param default_value Default value of the parameter (Typed value)
-     * @param cci_top_level_name Either the name should be absolute or relative
-     * @param desc Description of the paramaeter
-     * @param private_broker Associated private broker
-     * @param originator Originator of the parameter
-     */
-    cci_param_typed(const std::string& name, const value_type& default_value,
-                    cci_top_level_name, cci_broker_if& private_broker,
+                    cci_broker_if& private_broker,
                     const std::string& desc = "",
-                    const cci_originator& originator = cci_originator());
-
-    /**
-     * Constructor with (local/hierarchical) name, default value,
-     * private broker, top-level name, description and originator.
-     *
-     * @param name Name of the parameter
-     * @param default_value Default value of the parameter (CCI value)
-     * @param cci_top_level_name Either the name should be absolute or relative
-     * @param desc Description of the paramaeter
-     * @param private_broker Associated private broker
-     * @param originator Originator of the parameter
-     */
-    cci_param_typed(const std::string& name, const cci_value& default_value,
-                    cci_top_level_name, cci_broker_if& private_broker,
-                    const std::string& desc = "",
+                    cci_name_type name_type = CCI_RELATIVE_NAME,
                     const cci_originator& originator = cci_originator());
 
 protected:
@@ -565,23 +515,27 @@ void cci_param_typed<T, TM>::destroy()
 
 /// Constructors
 
-#define CCI_PARAM_CONSTRUCTOR_CCI_VALUE_IMPL(signature, top, broker)           \
+#define CCI_PARAM_CONSTRUCTOR_CCI_VALUE_IMPL(signature, broker)                \
 template <typename T, param_mutable_type TM>                                   \
 cci_param_typed<T, TM>::cci_param_typed signature                              \
-: cci_param_untyped(top, &broker, desc, originator),                           \
-  m_gs_param(new gs::gs_param<T>(name, "", NULL, top, true))                   \
+: cci_param_untyped((name_type == CCI_RELATIVE_NAME) ? false : true, &broker,  \
+                    desc, originator),                                         \
+  m_gs_param(new gs::gs_param<T>(name, "", NULL,                               \
+             (name_type == CCI_RELATIVE_NAME) ? false : true, true))           \
 {                                                                              \
-    m_gs_param->setString(default_value.to_json());                                    \
+    m_gs_param->setString(default_value.to_json());                            \
     cci_param_untyped::m_gs_param_base = m_gs_param;                           \
     broker.add_param(this);                                                    \
     this->init();                                                              \
 }
 
-#define CCI_PARAM_CONSTRUCTOR_IMPL(signature, top, broker)                     \
+#define CCI_PARAM_CONSTRUCTOR_IMPL(signature, broker)                          \
 template <typename T, param_mutable_type TM>                                   \
 cci_param_typed<T, TM>::cci_param_typed signature                              \
-: cci_param_untyped(top, &broker, desc, originator),                           \
-  m_gs_param(new gs::gs_param<T>(name, default_value, top))                    \
+: cci_param_untyped((name_type == CCI_RELATIVE_NAME) ? false : true,           \
+                     &broker, desc, originator),                               \
+  m_gs_param(new gs::gs_param<T>(name, default_value,                          \
+             (name_type == CCI_RELATIVE_NAME) ? false : true))                 \
 {                                                                              \
     cci_param_untyped::m_gs_param_base = m_gs_param;                           \
     cci_value init_value = broker.get_initial_cci_value(get_name());           \
@@ -592,86 +546,44 @@ cci_param_typed<T, TM>::cci_param_typed signature                              \
     this->init();                                                              \
 }
 
-/// Constructor with (local/hierarchical) name, default value, description
-/// and originator.
+/// Constructor with (local/hierarchical) name, default value, description,
+/// name type and originator.
 CCI_PARAM_CONSTRUCTOR_IMPL((const std::string& name,
 							const value_type& default_value,
                             const std::string& desc,
+                            cci_name_type name_type,
                             const cci_originator& originator),
-                            false,
                             cci_broker_manager::get_current_broker(
                                 originator))
 
-/// Constructor with (local/hierarchical) name, default value, description
-/// and originator.
+/// Constructor with (local/hierarchical) name, default value, description,
+/// name type and originator.
 CCI_PARAM_CONSTRUCTOR_CCI_VALUE_IMPL((const std::string& name,
                                       const cci_value& default_value,
                                       const std::string& desc,
+                                      cci_name_type name_type,
                                       const cci_originator& originator),
-                                      false,
-                                      cci_broker_manager::get_current_broker(
-                                          originator))
-
-/// Constructor with (local/hierarchical) name, default value, top-level name,
-/// description and originator.
-CCI_PARAM_CONSTRUCTOR_IMPL((const std::string& name,
-							const value_type& default_value,
-                            cci_top_level_name, const std::string& desc,
-                            const cci_originator& originator),
-                            true,
-                            cci_broker_manager::get_current_broker(
-                                originator))
-
-/// Constructor with (local/hierarchical) name, default value, top-level name,
-/// description and originator.
-CCI_PARAM_CONSTRUCTOR_CCI_VALUE_IMPL((const std::string& name,
-                                      const cci_value& default_value,
-                                      cci_top_level_name,
-                                      const std::string& desc,
-                                      const cci_originator& originator),
-                                      true,
                                       cci_broker_manager::get_current_broker(
                                           originator))
 
 /// Constructor with (local/hierarchical) name, default value, private broker,
-/// description and originator.
+/// description, name type and originator.
 CCI_PARAM_CONSTRUCTOR_IMPL((const std::string& name,
 							const value_type& default_value,
                             cci_broker_if& private_broker,
                             const std::string& desc,
+                            cci_name_type name_type,
                             const cci_originator& originator),
-                            false,
                             private_broker)
 
 /// Constructor with (local/hierarchical) name, default value, private broker,
-/// description and originator.
+/// description, name type and originator.
 CCI_PARAM_CONSTRUCTOR_CCI_VALUE_IMPL((const std::string& name,
                                       const cci_value& default_value,
                                       cci_broker_if& private_broker,
                                       const std::string& desc,
+                                      cci_name_type name_type,
                                       const cci_originator& originator),
-                                      false,
-                                      private_broker)
-
-/// Constructor with (local/hierarchical) name, default value, top-level name,
-/// private broker, description and originator.
-CCI_PARAM_CONSTRUCTOR_IMPL((const std::string& name,
-							const value_type& default_value,
-                            cci_top_level_name, cci_broker_if& private_broker,
-                            const std::string& desc,
-                            const cci_originator& originator),
-                            true,
-                            private_broker)
-
-/// Constructor with (local/hierarchical) name, default value, top-level name,
-/// private broker, description and originator.
-CCI_PARAM_CONSTRUCTOR_CCI_VALUE_IMPL((const std::string& name,
-                                      const cci_value& default_value,
-                                      cci_top_level_name,
-                                      cci_broker_if& private_broker,
-                                      const std::string& desc,
-                                      const cci_originator& originator),
-                                      true,
                                       private_broker)
 
 #undef CCI_PARAM_CONSTRUCTOR_IMPL


### PR DESCRIPTION
This PR adds support for top level parameter and is related to issue #59.
It's also related to PR #94 allowing the user to create an originator outside of SystemC context.
A new argument in the parameter constructor has been added : originator. To be consistent with other parts of CCI, user can pass a plain `cci_originator` instance and not just a name string (as `cci_broker_manager::get_current_broker(cci_originator())`).
