### PR TITLE
Include SystemC dynamic processes support by default

### DIFF
--- a/scripts/verify.pl
+++ b/scripts/verify.pl
@@ -911,7 +911,6 @@ sub prepare_environment
     # predefined macros
     @rt_defines = ();
     push @rt_defines, 'SC_ENABLE_ASSERTIONS';
-    push @rt_defines, 'SC_INCLUDE_DYNAMIC_PROCESSES'; # Required by GreenControl
 
     if( $rt_systemc_arch eq "gccsparcOS5" ) {
         $rt_ldrpath       = "-Wl,-R";

--- a/src/cci_core/systemc.h
+++ b/src/cci_core/systemc.h
@@ -32,6 +32,7 @@
  * (added in SystemC 2.3.1).
  *
  */
+
 #ifndef CCI_CORE_SYSTEMC_H_INCLUDED_
 #define CCI_CORE_SYSTEMC_H_INCLUDED_
 
@@ -39,6 +40,11 @@
 #pragma warning( push )
 #pragma warning( disable: 4244 )
 #pragma warning( disable: 4267 )
+#endif
+
+// Required by CCI callback mechanism using sc_unnamed bind argument
+#ifndef SC_INCLUDE_DYNAMIC_PROCESSES
+# define SC_INCLUDE_DYNAMIC_PROCESSES
 #endif
 
 #include <systemc>


### PR DESCRIPTION
This PR adds SystemC dynamic processes support by default as required by CCI callback (sc_unnamed).