### PR TITLE
Fix circular link dependency and static initialisation

### DIFF
--- a/scripts/verify.pl
+++ b/scripts/verify.pl
@@ -926,7 +926,7 @@ sub prepare_environment
     push( @rt_cci_includes, "$rt_cci_home/packages" );
 
     $rt_cci_ldpath   = $rt_cci_home;
-    @rt_cci_ldlibs   = ( 'cciapi', 'ccibrokerimpl' );
+    @rt_cci_ldlibs   = ( 'cciapi', 'ccibrokerimpl', 'cciapi' );
     # -- /CCI
 
     # Set compiler and compiler flags

--- a/src/cci_core/cci_name_gen.h
+++ b/src/cci_core/cci_name_gen.h
@@ -53,16 +53,6 @@ const char* cci_get_name(const char* name);
  */
 bool cci_unregister_name(const char* name);
 
-#if CCI_SYSTEMC_VERSION_CODE_ < CCI_VERSION_HELPER_(2,3,2)
-enum cci_name_state {
-    cci_name_free,
-    cci_name_used
-};
-
-/// CCI unique names map used when SystemC < 2.3.2
-extern std::map<std::string, std::pair<int, cci_name_state> > cci_unique_names;
-#endif
-
 CCI_CLOSE_NAMESPACE_
 
 #endif


### PR DESCRIPTION
This PR fixes two issues reported by @liangleise (thanks to him).
- CCI API lib and CCI Broker Impl lib are circularly dependent. However, each mention of a library during the link will cause resolution of libraries that came before it. This PR adds another ccibrokerimpl dependency in the `verify.pl` script in order to fix it.
- Fix a possible static initialisation order fiasco in `cci_name_gen` using SystemC < 2.3.2.

Guillaume