### PR TITLE
Rename cci::detail namespace to cci::cci_impl

### DIFF
--- a/src/cci_cfg/cci_param_callbacks.h
+++ b/src/cci_cfg/cci_param_callbacks.h
@@ -86,7 +86,7 @@ struct cci_param_write_event
 
     cci_value old_value;
     cci_value new_value;
-    typename detail::remove_reference<generic_type>::type wrapped_value;
+    typename cci_impl::remove_reference<generic_type>::type wrapped_value;
   }; // struct generic_wrap
 
 }; // cci_param_write_event
@@ -141,7 +141,7 @@ struct cci_param_read_event
         explicit generic_wrap(const type& payload);
 
         cci_value value;
-        typename detail::remove_reference<generic_type>::type wrapped_value;
+        typename cci_impl::remove_reference<generic_type>::type wrapped_value;
     }; // struct generic_wrap
 
 }; // cci_param_read_event

--- a/src/cci_cfg/cci_param_typed.h
+++ b/src/cci_cfg/cci_param_typed.h
@@ -37,7 +37,8 @@ CCI_OPEN_NAMESPACE_
 template<class T>
 class cci_param_typed_handle;
 
-namespace detail {
+///@cond CCI_HIDDEN_FROM_DOXYGEN
+namespace cci_impl {
 /// implementation defined helper to set/reset a boolean flag
 struct scoped_true {
     explicit scoped_true(bool& ref) : ref_(ref) { ref_ = true; }
@@ -45,7 +46,8 @@ struct scoped_true {
 private:
     bool& ref_;
 }; // class scoped_true
-}  // namespace detail
+}  // namespace cci_impl
+///@endcond
 
 /// Parameter class, internally forwarding calls to the implementation
 /**
@@ -663,7 +665,7 @@ private:
             return false;
 
         // Lock the tag to prevent nested callback
-        detail::scoped_true oncall( m_pre_write_callbacks.oncall );
+        cci_impl::scoped_true oncall( m_pre_write_callbacks.oncall );
 
         bool result = true;
         // Validate write callbacks
@@ -701,7 +703,7 @@ private:
             return;
 
         // Lock the tag to prevent nested callback
-        detail::scoped_true oncall( m_post_write_callbacks.oncall );
+        cci_impl::scoped_true oncall( m_post_write_callbacks.oncall );
 
         // Write callbacks
         for (unsigned i = 0; i < m_post_write_callbacks.vec.size(); ++i) {
@@ -731,7 +733,7 @@ private:
           return;
 
         // Lock the tag to prevent nested callback
-        detail::scoped_true oncall( m_pre_read_callbacks.oncall );
+        cci_impl::scoped_true oncall( m_pre_read_callbacks.oncall );
 
         // Read callbacks
         for (unsigned i = 0; i < m_pre_read_callbacks.vec.size(); ++i) {
@@ -761,7 +763,7 @@ private:
             return;
 
         // Lock the tag to prevent nested callback
-        detail::scoped_true oncall( m_post_read_callbacks.oncall );
+        cci_impl::scoped_true oncall( m_post_read_callbacks.oncall );
 
         // Read callbacks
         for (unsigned i = 0; i < m_post_read_callbacks.vec.size(); ++i) {

--- a/src/cci_core/cci_callback.h
+++ b/src/cci_core/cci_callback.h
@@ -104,10 +104,12 @@ public:
   template< typename T >
   cci_callback( const cci_callback<T>& cb
 #ifndef CCI_DOXYGEN_IS_RUNNING
-              , typename detail::enable_if<detail::callback_is_generalized<traits,T>::value >::type* = NULL
+              , typename cci_impl::enable_if<
+                  cci_impl::callback_is_generalized<traits,T>::value
+                >::type* = NULL
 #endif // CCI_DOXYGEN_IS_RUNNING
               )
-    : m_cb( new detail::callback_generic_adapt<traits>(cb.m_cb) )
+    : m_cb( new cci_impl::callback_generic_adapt<traits>(cb.m_cb) )
   {}
 
   cci_callback& operator=(cci_callback copy)
@@ -121,7 +123,7 @@ public:
     // http://talesofcpp.fusionfenix.com/post-11/true-story-call-me-maybe
   >
   cci_callback( C c )
-    : m_cb( new detail::callback_impl<C,traits>(CCI_MOVE_(c)) )
+    : m_cb( new cci_impl::callback_impl<C,traits>(CCI_MOVE_(c)) )
   {}
 
   void swap(cci_callback& that)
@@ -145,7 +147,7 @@ public:
   }
 
 private:
-  typedef detail::callback_typed_if<traits> impl_if;
+  typedef cci_impl::callback_typed_if<traits> impl_if;
   impl_if* m_cb;
 };
 
@@ -273,14 +275,14 @@ public:
   }
 
 protected:
-  const detail::callback_untyped_if * get() const
+  const cci_impl::callback_untyped_if * get() const
   {
     if (m_cb)
       return m_cb->get();
     return NULL;
   }
 
-  void reset(detail::callback_untyped_if* cb)
+  void reset(cci_impl::callback_untyped_if* cb)
   {
     if (m_cb) m_cb->release();
     m_cb = cb;
@@ -288,7 +290,7 @@ protected:
   }
 
 private:
-  detail::callback_untyped_if * m_cb;
+  cci_impl::callback_untyped_if * m_cb;
 };
 
 /* ------------------------------------------------------------------------ */
@@ -359,7 +361,7 @@ bool
 cci_callback_untyped_handle::valid() const
 {
   typedef cci_callback_traits<ArgType,ResultType> traits;
-  typedef detail::callback_typed_if<traits> if_type;
+  typedef cci_impl::callback_typed_if<traits> if_type;
   return m_cb && dynamic_cast<const if_type*>(m_cb);
 }
 
@@ -368,7 +370,7 @@ ResultType
 cci_callback_untyped_handle::invoke(ArgType arg) const
 {
   typedef cci_callback_traits<ArgType,ResultType> traits;
-  typedef detail::callback_typed_if<traits> if_type;
+  typedef cci_impl::callback_typed_if<traits> if_type;
   const if_type* typed_cb = dynamic_cast<const if_type*>(m_cb);
 
   sc_assert( m_cb );            /// \todo Add proper error handling
@@ -381,7 +383,7 @@ ResultType
 cci_callback_untyped_handle::unchecked_invoke(ArgType arg) const
 {
   typedef cci_callback_traits<ArgType,ResultType> traits;
-  typedef detail::callback_typed_if<traits> if_type;
+  typedef cci_impl::callback_typed_if<traits> if_type;
 
   sc_assert( m_cb );            /// \todo Add proper error handling
   const if_type* typed_cb = static_cast<const if_type*>(m_cb);
@@ -403,8 +405,8 @@ cci_callback_typed_handle<ArgType,ResultType>::
 
   // check, if convertible from a generic handle
   typedef cci_callback_traits<ArgType,ResultType> traits;
-  detail::callback_untyped_if* cb_adapt
-    = detail::callback_generic_adapt<traits>::convert(this->get());
+  cci_impl::callback_untyped_if* cb_adapt
+    = cci_impl::callback_generic_adapt<traits>::convert(this->get());
   this->reset(cb_adapt);
   if (cb_adapt) cb_adapt->release();
 }

--- a/src/cci_core/cci_callback_impl.h
+++ b/src/cci_core/cci_callback_impl.h
@@ -22,7 +22,7 @@
 * \author Philipp A. Hartmann, Intel
 * \brief  Callback implementation classes
 *
-* \note Any classes defined in the \ref cci::detail namespace
+* \note Any classes defined in the \ref cci::cci_impl namespace
 *       are not part of the CCI standard.
 */
 #ifndef CCI_CORE_CCI_CALLBACK_IMPL_H_INCLUDED_
@@ -32,7 +32,8 @@
 #include "cci_core/cci_meta.h"
 
 CCI_OPEN_NAMESPACE_
-namespace detail {
+///@cond CCI_HIDDEN_FROM_DOXYGEN
+namespace cci_impl {
 
 /// implementation-defined helper to define default callback traits
 template<typename ArgType, typename ResultType, typename GenericType = void>
@@ -47,12 +48,12 @@ struct callback_traits
 /// implementation-defined helper to define generalizable callback traits
 template<typename ArgType, typename ResultType>
 class callback_traits<ArgType, ResultType,
-  typename detail::always_void<
-    typename detail::remove_reference<ArgType>::type::generic_type
+  typename cci_impl::always_void<
+    typename cci_impl::remove_reference<ArgType>::type::generic_type
   >::type
 >
 {
-  typedef typename detail::remove_reference<ArgType>::type nonref_argtype;
+  typedef typename cci_impl::remove_reference<ArgType>::type nonref_argtype;
 public:
   typedef ArgType argument_type;
   typedef ResultType result_type;
@@ -63,16 +64,18 @@ public:
   static const bool is_generalizable = true;
 };
 
-} // namespace detail
+} // namespace cci_impl
+///@endcond
 
 /// default callback traits
 template<typename ArgType, typename ResultType>
 struct cci_callback_traits
-  : detail::callback_traits<ArgType, ResultType> {};
+  : cci_impl::callback_traits<ArgType, ResultType> {};
 
 /* ------------------------------------------------------------------------ */
 
-namespace detail {
+///@cond CCI_HIDDEN_FROM_DOXYGEN
+namespace cci_impl {
 
 struct callback_untyped_if
 {
@@ -230,7 +233,8 @@ protected:
   unsigned m_refcnt;
 };
 
-} // namespace detail
+} // namespace cci_impl
+///@endcond
 CCI_CLOSE_NAMESPACE_
 
 #endif // CCI_CORE_CCI_CALLBACK_IMPL_H_INCLUDED_

--- a/src/cci_core/cci_meta.h
+++ b/src/cci_core/cci_meta.h
@@ -46,7 +46,7 @@ template<typename T> struct cci_typed_tag : cci_tag<T> {};
 typedef cci_tag<void> cci_untyped_tag;
 
 ///@cond CCI_HIDDEN_FROM_DOXYGEN
-namespace detail {
+namespace cci_impl {
 
 #if CCI_CPLUSPLUS >= 201103L
 using std::enable_if;
@@ -83,7 +83,7 @@ template<typename T> struct remove_reference<T&> { typedef T type; };
 /// C++03 implementation of std::void_t (from C++17)
 template<typename T> struct always_void { typedef void type; };
 
-} // namespace detail
+} // namespace cci_impl
 ///@endcond
 CCI_CLOSE_NAMESPACE_
 

--- a/src/cci_core/cci_value.cpp
+++ b/src/cci_core/cci_value.cpp
@@ -31,6 +31,7 @@
 
 CCI_OPEN_NAMESPACE_
 
+///@cond CCI_HIDDEN_FROM_DOXYGEN
 namespace /* anonymous */ {
 
 typedef rapidjson::CrtAllocator allocator_type;
@@ -81,7 +82,6 @@ impl_type* impl_pool::free_list_;
 
 } // anonymous namespace
 
-///@cond CCI_HIDDEN_FROM_DOXYGEN
 #define PIMPL( x ) \
   (impl_cast((x).pimpl_))
 
@@ -404,7 +404,8 @@ cci_value_string_ref::swap(this_type & that)
 // ----------------------------------------------------------------------------
 // cci_value_list/map::(const_)iterator
 
-namespace detail {
+///@cond CCI_HIDDEN_FROM_DOXYGEN
+namespace cci_impl {
 
 struct value_iterator_list_tag {};
 struct value_iterator_map_tag {};
@@ -457,7 +458,8 @@ template class value_iterator_impl<cci_value_cref>;
 template class value_iterator_impl<cci_value_ref>;
 template class value_iterator_impl<cci_value_map_elem_cref>;
 template class value_iterator_impl<cci_value_map_elem_ref>;
-} // namespace detail
+} // namespace cci_impl
+///@endcond
 
 template class cci_value_iterator<cci_value_cref>;
 template class cci_value_iterator<cci_value_ref>;

--- a/src/cci_core/cci_value.h
+++ b/src/cci_core/cci_value.h
@@ -104,13 +104,13 @@ class cci_value_cref
   friend class cci_value_map_cref;
   friend class cci_value_map_ref;
   friend class cci_value_map_elem_cref;
-  template<typename U> friend class detail::value_iterator_impl;
+  template<typename U> friend class cci_impl::value_iterator_impl;
   friend bool operator==( cci_value_cref const &, cci_value_cref const & );
   friend std::ostream& operator<<( std::ostream&, cci_value_cref const & );
 
 protected:
   typedef void* impl_type; // use type-punned pointer for now
-  typedef detail::value_ptr<cci_value_cref> proxy_ptr;
+  typedef cci_impl::value_ptr<cci_value_cref> proxy_ptr;
 
   explicit cci_value_cref(impl_type i = NULL)
     : pimpl_(i) {}
@@ -253,12 +253,12 @@ class cci_value_ref
   friend class cci_value_list_ref;
   friend class cci_value_map_ref;
   friend class cci_value_map_elem_ref;
-  template<typename U> friend class detail::value_iterator_impl;
+  template<typename U> friend class cci_impl::value_iterator_impl;
   friend std::istream& operator>>( std::istream&, cci_value_ref );
   typedef cci_value_cref base_type;
   typedef cci_value_ref  this_type;
 
-  typedef detail::value_ptr<this_type> proxy_ptr;
+  typedef cci_impl::value_ptr<this_type> proxy_ptr;
 protected:
   explicit cci_value_ref(impl_type i = NULL)
     : cci_value_cref(i) {}
@@ -398,7 +398,7 @@ class cci_value_string_cref
   friend class cci_value_map_elem_ref;
   typedef cci_value_cref        base_type;
   typedef cci_value_string_cref this_type;
-  typedef detail::value_ptr<this_type> proxy_ptr;
+  typedef cci_impl::value_ptr<this_type> proxy_ptr;
 
 protected:
   explicit cci_value_string_cref(impl_type i = NULL)
@@ -469,7 +469,7 @@ class cci_value_string_ref
   friend class cci_value_ref;
   typedef cci_value_string_cref base_type;
   typedef cci_value_string_ref  this_type;
-  typedef detail::value_ptr<this_type> proxy_ptr;
+  typedef cci_impl::value_ptr<this_type> proxy_ptr;
 
 protected:
   explicit cci_value_string_ref(impl_type i = NULL)
@@ -528,10 +528,10 @@ cci_value_ref::set_string(std::string const & s)
 
 ///@cond CCI_HIDDEN_FROM_DOXYGEN
 // iterator implementations in cci_value.cpp
-namespace detail {
+namespace cci_impl {
 CCI_TPLEXTERN_ template class value_iterator_impl<cci_value_ref>;
 CCI_TPLEXTERN_ template class value_iterator_impl<cci_value_cref>;
-} // namespace detail
+} // namespace cci_impl
 CCI_TPLEXTERN_ template class cci_value_iterator<cci_value_cref>;
 CCI_TPLEXTERN_ template class cci_value_iterator<cci_value_ref>;
 ///@endcond
@@ -543,7 +543,7 @@ class cci_value_list_cref
   friend class cci_value_cref;
   typedef cci_value_cref      base_type;
   typedef cci_value_list_cref this_type;
-  typedef detail::value_ptr<this_type> proxy_ptr;
+  typedef cci_impl::value_ptr<this_type> proxy_ptr;
 
 protected:
   explicit cci_value_list_cref(impl_type i = NULL)
@@ -627,7 +627,7 @@ class cci_value_list_ref
   friend class cci_value_ref;
   typedef cci_value_list_cref base_type;
   typedef cci_value_list_ref  this_type;
-  typedef detail::value_ptr<this_type> proxy_ptr;
+  typedef cci_impl::value_ptr<this_type> proxy_ptr;
 
 protected:
   explicit cci_value_list_ref(impl_type i = NULL)
@@ -737,8 +737,8 @@ cci_value_ref::get_list()
 /// reference to a constant cci_value map element
 class cci_value_map_elem_cref
 {
-  template<typename U> friend class detail::value_iterator_impl;
-  typedef detail::value_ptr<cci_value_map_elem_cref> proxy_ptr;
+  template<typename U> friend class cci_impl::value_iterator_impl;
+  typedef cci_impl::value_ptr<cci_value_map_elem_cref> proxy_ptr;
 
   typedef void value_type; // TODO: add  explicit value_type 
 public:
@@ -762,8 +762,8 @@ protected:
 /// reference to a mutable cci_value map element
 class cci_value_map_elem_ref
 {
-  template<typename U> friend class detail::value_iterator_impl;
-  typedef detail::value_ptr<cci_value_map_elem_ref> proxy_ptr;
+  template<typename U> friend class cci_impl::value_iterator_impl;
+  typedef cci_impl::value_ptr<cci_value_map_elem_ref> proxy_ptr;
   typedef void value_type; // TODO: add  explicit value_type
 public:
   typedef cci_value_map_elem_cref const_reference;
@@ -785,10 +785,10 @@ protected:
 
 ///@cond CCI_HIDDEN_FROM_DOXYGEN
 // iterator implementations in cci_value.cpp
-namespace detail {
+namespace cci_impl {
 CCI_TPLEXTERN_ template class value_iterator_impl<cci_value_map_elem_cref>;
 CCI_TPLEXTERN_ template class value_iterator_impl<cci_value_map_elem_ref>;
-} // namespace detail
+} // namespace cci_impl
 CCI_TPLEXTERN_ template class cci_value_iterator<cci_value_map_elem_cref>;
 CCI_TPLEXTERN_ template class cci_value_iterator<cci_value_map_elem_ref>;
 ///@endcond
@@ -800,7 +800,7 @@ class cci_value_map_cref
   friend class cci_value_cref;
   typedef cci_value_cref     base_type;
   typedef cci_value_map_cref this_type;
-  typedef detail::value_ptr<this_type> proxy_ptr;
+  typedef cci_impl::value_ptr<this_type> proxy_ptr;
 
 protected:
   explicit cci_value_map_cref(impl_type i = NULL)
@@ -897,7 +897,7 @@ class cci_value_map_ref
   friend class cci_value_ref;
   typedef cci_value_map_cref base_type;
   typedef cci_value_map_ref  this_type;
-  typedef detail::value_ptr<this_type> proxy_ptr;
+  typedef cci_impl::value_ptr<this_type> proxy_ptr;
 protected:
   explicit cci_value_map_ref(impl_type i = NULL)
     : base_type(i) {}

--- a/src/cci_core/cci_value_iterator.h
+++ b/src/cci_core/cci_value_iterator.h
@@ -43,7 +43,7 @@ class cci_value_map_elem_cref;
 template<typename T> class cci_value_iterator;
 
 ///@cond CCI_HIDDEN_FROM_DOXYGEN
-namespace detail {
+namespace cci_impl {
 
 /// helper class to avoid dangling pointers to cci_value reference objects
 template<typename T> struct value_ptr
@@ -100,7 +100,7 @@ private:
   impl_type  impl_; // underlying iterator,
 };
 
-} // namespace detail
+} // namespace cci_impl
 ///@endcond
 
 /**
@@ -110,9 +110,9 @@ private:
  */
 template<typename T>
 class cci_value_iterator
-  : protected detail::value_iterator_impl<T>
+  : protected cci_impl::value_iterator_impl<T>
 {
-  typedef detail::value_iterator_impl<T> impl;
+  typedef cci_impl::value_iterator_impl<T> impl;
   typedef cci_value_iterator<typename T::const_reference> const_type;
   typedef cci_value_iterator<typename T::reference>       nonconst_type;
 


### PR DESCRIPTION
Most implementation-defined classes are currently placed in a nested `cci::detail` namespace.  As discussed in #166, this patch renames the namespace to `cci_impl` to better document the intent and to reduce risk of naming conflict in the presence of using directives.

Additionally, add some more doxygen suppressions.

No functional changes.