### PR TITLE
cci_value: add support for pointer_traits

### DIFF
--- a/src/cci_core/cci_value.h
+++ b/src/cci_core/cci_value.h
@@ -206,7 +206,10 @@ public:
    * objects (cci_value, cci_value_list, cci_value_map) provide default
    * \c addressof semantics again.
    */
-  proxy_ptr operator&() const { return proxy_ptr(pimpl_,*this); }
+  proxy_ptr operator&() const { return proxy_ptr(*this); }
+
+  /// Does this reference point to the same value as another reference?
+  bool is_same(cci_value_cref that) const { return pimpl_ == that.pimpl_; }
 
 protected:
   void
@@ -353,7 +356,7 @@ public:
   ///@}
 
   /// @copydoc cci_value_cref::operator&
-  proxy_ptr operator&() const { return proxy_ptr(pimpl_,*this); }
+  proxy_ptr operator&() const { return proxy_ptr(*this); }
 protected:
   /// try to set the value from a JSON-encoded string
   bool json_deserialize( std::string const& );
@@ -436,7 +439,7 @@ public:
   //@}
 
   /// @copydoc cci_value_cref::operator&
-  proxy_ptr operator&() const { return proxy_ptr(pimpl_,*this); }
+  proxy_ptr operator&() const { return proxy_ptr(*this); }
 
 private:
   // exclude non-string value functions
@@ -494,7 +497,7 @@ public:
   //@}
 
   /// @copydoc cci_value_cref::operator&
-  proxy_ptr operator&() const { return proxy_ptr(pimpl_,*this); }
+  proxy_ptr operator&() const { return proxy_ptr(*this); }
 };
 
 inline cci_value_string_ref
@@ -616,7 +619,7 @@ public:
   //@}
 
   /// @copydoc cci_value_cref::operator&
-  proxy_ptr operator&() const { return proxy_ptr(pimpl_,*this); }
+  proxy_ptr operator&() const { return proxy_ptr(*this); }
 
 private:
   // exclude non-list value functions
@@ -740,7 +743,7 @@ public:
   //@}
 
   /// @copydoc cci_value_cref::operator&
-  proxy_ptr operator&() const { return proxy_ptr(pimpl_,*this); }
+  proxy_ptr operator&() const { return proxy_ptr(*this); }
 };
 
 inline cci_value_list_ref
@@ -782,7 +785,10 @@ public:
   cci_value_cref        value;
 
   /// @copydoc cci_value_cref::operator&
-  proxy_ptr operator&() const { return proxy_ptr(pimpl_,*this); }
+  proxy_ptr operator&() const { return proxy_ptr(*this); }
+
+  /// Does this reference point to the same value as another reference?
+  bool is_same(cci_value_map_elem_cref that) const { return pimpl_ == that.pimpl_; }
 
 protected:
   typedef void* impl_type; // use type-punned pointer for now
@@ -806,7 +812,7 @@ public:
   cci_value_ref         value;
 
   /// @copydoc cci_value_cref::operator&
-  proxy_ptr operator&() const { return proxy_ptr(pimpl_,*this); }
+  proxy_ptr operator&() const { return proxy_ptr(*this); }
 
 protected:
   typedef void* impl_type; // use type-punned pointer for now
@@ -918,7 +924,7 @@ public:
   //@}
 
   /// @copydoc cci_value_cref::operator&
-  proxy_ptr operator&() const { return proxy_ptr(pimpl_,*this); }
+  proxy_ptr operator&() const { return proxy_ptr(*this); }
 
 protected:
   enum lookup_mode { KEY_REQUIRED = 0, KEY_OPTIONAL, KEY_CREATE };
@@ -1079,7 +1085,7 @@ public:
   //@}
 
   /// @copydoc cci_value_cref::operator&
-  proxy_ptr operator&() const { return proxy_ptr(pimpl_,*this); }
+  proxy_ptr operator&() const { return proxy_ptr(*this); }
 
 private:
   template<typename T>

--- a/src/cci_core/cci_value_iterator.h
+++ b/src/cci_core/cci_value_iterator.h
@@ -48,20 +48,21 @@ namespace cci_impl {
 /// helper class to avoid dangling pointers to cci_value reference objects
 template<typename T> struct value_ptr
 {
-  explicit value_ptr(void* r, const T& ref) : raw_(r), ref_(ref) {}
+  typedef T element_type;
+
+  explicit value_ptr(const T& ref) : ref_(ref) {}
 
   T& operator*()  { return ref_; }
   T* operator->() { return ptr(); }
 
-  bool operator==(const value_ptr& that) const { return raw() == that.raw(); }
+  bool operator==(const value_ptr& that) const { return ref_.is_same() == (*that).is_same(); }
   bool operator!=(const value_ptr& that) const { return !(*this == that); }
 
-private:
-  void* raw() const
-    { return raw_; }
-  T* ptr() { return reinterpret_cast<T*>(&reinterpret_cast<unsigned char&>(ref_)); }
+  static value_ptr pointer_to(element_type& elem) { return value_ptr(elem); }
 
-  void* raw_;
+private:
+  // avoid addressof operator
+  T* ptr() { return reinterpret_cast<T*>(&reinterpret_cast<unsigned char&>(ref_)); }
   T ref_; // extend lifetime of reference
 };
 
@@ -90,7 +91,7 @@ protected:
 
   int compare(impl_type) const;
 
-  pointer   ptr()   const { return pointer(raw(),deref()); }
+  pointer   ptr()   const { return pointer(deref()); }
   reference deref() const { return reference(raw()); }
   impl_type raw()   const { return impl_; }
 


### PR DESCRIPTION
MSVC'2015 already uses the C++11 [`std::pointer_traits<Ptr>`][1] class in some cases, e.g. for implementing the `std::reverse_iterator`. This requires the addition of two symbols to the internal helper
class `cci_impl::value_ptr`:

```cpp
  typedef T element_type;
  static value_ptr pointer_to(element_type& elem);
```

In order to enable the implementation of `pointer_to` the `value_ptr` has been simplified to avoid the need for the `raw()` member function by adding an (implementation-defined) function
```cpp
  bool is_same(const_reference) const;
```
to the relevant reference wrappers `cci_value_(map_elem_)cref`.

Reported-by: Trevor Wieman (@twieman)

[1]: http://en.cppreference.com/w/cpp/memory/pointer_traits