### PR TITLE
CCI_NUMBER_(PARAM,VALUE) -> CCI_INTEGRAL_(PARAM,VALUE)

### DIFF
--- a/examples/ex02_Fully_Supported_Data_Type_Param/ex02_config_ip.h
+++ b/examples/ex02_Fully_Supported_Data_Type_Param/ex02_config_ip.h
@@ -68,10 +68,10 @@ SC_MODULE(ex02_config_ip) {
       sc_assert(int_param_handle.is_valid());
       cci::cci_param_data_category partype = cci::CCI_OTHER_PARAM;
       partype = int_param_handle.get_data_category();
-      if(partype == cci::CCI_NUMBER_PARAM) {
-        XREPORT("@execute: Type of " << param_name << " is a number.");
+      if(partype == cci::CCI_INTEGRAL_PARAM) {
+        XREPORT("@execute: Type of " << param_name << " is an integer.");
       } else {
-        XREPORT_ERROR("@execute: Type of " << param_name << " is not a number.");
+        XREPORT_ERROR("@execute: Type of " << param_name << " is not an integer.");
       }
 
       // Convert the untyped handle of the param to a typed handle 'int' 

--- a/examples/ex02_Fully_Supported_Data_Type_Param/golden/ex02_Fully_Supported_Data_Type_Param.log
+++ b/examples/ex02_Fully_Supported_Data_Type_Param/golden/ex02_Fully_Supported_Data_Type_Param.log
@@ -22,7 +22,7 @@ Info: sim_ip: @0 s, @Ctor: Default value of sim_ip.string_param is C++ String
 
 Info: sc_main: Begin Simulation.
 
-Info: cfg_ip: @10 ns, @execute: Type of sim_ip.int_param is a number.
+Info: cfg_ip: @10 ns, @execute: Type of sim_ip.int_param is an integer.
 
 Info: cfg_ip: @10 ns, @execute: Typecast of sim_ip.int_param to 'cci::cci_param_typed_handle<int> *' succeeded
 

--- a/examples/ex22_Search_Predicate/ex22_search_ip.h
+++ b/examples/ex22_Search_Predicate/ex22_search_ip.h
@@ -49,7 +49,7 @@ public:
     static bool
     integer_type_predicate(const cci::cci_param_untyped_handle handle)
     {
-        return (handle.get_data_category() == cci::CCI_NUMBER_PARAM);
+        return (handle.get_data_category() == cci::CCI_INTEGRAL_PARAM);
     }
 
     static bool
@@ -63,7 +63,7 @@ public:
                              double greater_eq, double lower)
     {
         if(handle.get_data_category() == cci::CCI_REAL_PARAM
-           || handle.get_data_category() == cci::CCI_NUMBER_PARAM) {
+           || handle.get_data_category() == cci::CCI_INTEGRAL_PARAM) {
             return (handle.get_cci_value().get_double() >= greater_eq
                     && handle.get_cci_value().get_double() < lower);
         }

--- a/src/cci_cfg/cci_param_typed.h
+++ b/src/cci_cfg/cci_param_typed.h
@@ -909,8 +909,8 @@ cci_param_data_category cci_param_typed<T, TM>::get_data_category() const
 	{
     case CCI_BOOL_VALUE:
         return CCI_BOOL_PARAM;
-	case CCI_NUMBER_VALUE:
-		return CCI_NUMBER_PARAM;
+	case CCI_INTEGRAL_VALUE:
+		return CCI_INTEGRAL_PARAM;
 	case CCI_REAL_VALUE:
 		return CCI_REAL_PARAM;
 	case CCI_STRING_VALUE:

--- a/src/cci_core/cci_core_types.h
+++ b/src/cci_core/cci_core_types.h
@@ -32,7 +32,7 @@ enum cci_param_data_category {
     /// Boolean valued parameter
     CCI_BOOL_PARAM,
     /// Integer number valued parameter
-    CCI_NUMBER_PARAM,
+    CCI_INTEGRAL_PARAM,
     /// Real number valued parameter
     CCI_REAL_PARAM,
     /// String valued parameter

--- a/src/cci_core/cci_value.cpp
+++ b/src/cci_core/cci_value.cpp
@@ -138,7 +138,7 @@ cci_value_cref::category() const
     return CCI_BOOL_VALUE;
 
   case rapidjson::kNumberType:
-    return THIS->IsDouble() ? CCI_REAL_VALUE : CCI_NUMBER_VALUE;
+    return THIS->IsDouble() ? CCI_REAL_VALUE : CCI_INTEGRAL_VALUE;
 
   case rapidjson::kStringType:
     return CCI_STRING_VALUE;

--- a/src/cci_core/cci_value.h
+++ b/src/cci_core/cci_value.h
@@ -64,7 +64,7 @@ enum cci_value_category {
 	/// A boolean valued component of data
 	CCI_BOOL_VALUE,
 	/// An integer number component of data
-	CCI_NUMBER_VALUE,
+	CCI_INTEGRAL_VALUE,
 	/// A real number number component of data
 	CCI_REAL_VALUE,
 	/// A string component of data


### PR DESCRIPTION
As noted by @thomasgoodfellow in the LRM drafts, `CCI_NUMBER_VALUE` is currently inconsistent with `cci_value::is_number`:

>  Could this be renamed to `CCI_INTEGER_VALUE`? `cci_value::is_number()`
>  explicitly treats integer & double as being "number" which agrees
>  with common usage

This PR suggests `CCI_INTEGRAL_VALUE` instead, inspired by [`std::is_integral`][1].  Adjust  `CCI_NUMBER_PARAM` accordingly.

[1]: http://en.cppreference.com/w/cpp/types/is_integral