### PR TITLE
cci_param_untyped: add missing callback unregistration

### DIFF
--- a/src/cci_cfg/cci_param_untyped.cpp
+++ b/src/cci_cfg/cci_param_untyped.cpp
@@ -169,6 +169,13 @@ cci_param_untyped::unregister_##name##_callback(                               \
         }                                                                      \
     }                                                                          \
     return false;                                                              \
+}                                                                              \
+                                                                               \
+bool                                                                           \
+cci_param_untyped::unregister_##name##_callback(                               \
+        const cci_callback_untyped_handle &cb)                                 \
+{                                                                              \
+    return unregister_##name##_callback(cb, m_originator);                     \
 }
 
 CCI_PARAM_UNTYPED_CALLBACK_IMPL_(pre_write)


### PR DESCRIPTION
This pull-request adds the missing definition of the (untyped) callback unregister functions (without explicit originator) by delegating to the explicit originator overloads.

Closes #167.