### PR TITLE
ex16: move converter specialization CCI namespace

### DIFF
--- a/examples/ex16_User_Defined_Data_Type/ex16_user_datatype.h
+++ b/examples/ex16_User_Defined_Data_Type/ex16_user_datatype.h
@@ -76,8 +76,9 @@ struct route_table_ut {
 };
 
 // add support for cci_value and JSON (de)serialization
+namespace cci {
 template<>
-struct cci::cci_value_converter< route_table_ut >
+struct cci_value_converter< route_table_ut >
 {
   typedef route_table_ut type;
   static bool pack( cci_value::reference dst, type const & src )
@@ -105,6 +106,7 @@ struct cci::cci_value_converter< route_table_ut >
     return false;
   }
 };
+} // namespace cci
 
 // Overload stream insertion operator of C++
 std::ostream& operator <<(std::ostream& os, const route_table_ut& ud)


### PR DESCRIPTION
Instead of defining the `cci::cci_value_converter` specialization outside of the cci namespace, move it into the cci namespace explicitly.

Should fix compile error reported in the [public review forum][1].

[1]: http://forums.accellera.org/topic/5986-systemc-cci-build-issues/