### PR TITLE
Remove local originator from utils broker

### DIFF
--- a/src/cci_cfg/cci_broker_handle.h
+++ b/src/cci_cfg/cci_broker_handle.h
@@ -184,6 +184,7 @@ public:
     }
 
 private:
+    friend class cci_broker_if;
     friend class cci_param_if;
     cci_broker_if&       ref()       { return *m_broker; }
     const cci_broker_if& ref() const { return *m_broker; }

--- a/src/cci_cfg/cci_broker_if.h
+++ b/src/cci_cfg/cci_broker_if.h
@@ -183,9 +183,11 @@ public:
      *
      *
      * @param parname  Full hierarchical name of the parameter whose value should be returned.
+     * @param   originator Reference to the originator
      * @return  CCI value of the parameter
      */
-    virtual cci::cci_value get_cci_value(const std::string &parname) const = 0;
+    virtual cci::cci_value get_cci_value(const std::string &parname,
+        const cci_originator &originator = cci_originator()) const = 0;
     
     /// Get a parameter handle.
     /**
@@ -272,6 +274,9 @@ protected:
 
     cci_originator unknown_originator() const
       { return cci_originator( cci_originator::unknown_tag() ); }
+
+    static cci_broker_if &unwrap_broker(cci_broker_handle &h)
+    { return h.ref(); }
 };
 
 inline cci_broker_handle

--- a/src/cci_utils/broker.cpp
+++ b/src/cci_utils/broker.cpp
@@ -43,7 +43,7 @@ namespace cci_utils {
  */
   broker::broker(const std::string& name)
     : consuming_broker(name),
-    m_parent(get_parent_broker(m_originator)) // local convenience function
+    m_parent(get_parent_broker()) // local convenience function
     { 
       sc_assert (name.length() > 0 && "Name must not be empty");
     }
@@ -114,7 +114,7 @@ namespace cci_utils {
     const cci_originator& originator)
   {
     if (sendToParent(parname)) {
-      return m_parent.set_preset_cci_value(parname,cci_value);
+      return m_parent.set_preset_cci_value(parname,cci_value, originator);
     } else {
       return consuming_broker::set_preset_cci_value(parname,cci_value,originator);
     }
@@ -124,14 +124,14 @@ namespace cci_utils {
     const cci_originator& originator) const
   {
     if (sendToParent(parname)) {
-      return m_parent.get_param_handle(parname);
+      return m_parent.get_param_handle(parname, originator);
     }
     cci_param_if* orig_param = get_orig_param(parname);
     if (orig_param) {
       return cci_param_untyped_handle(*orig_param, originator);
     }
     if (has_parent) {
-      return m_parent.get_param_handle(parname);
+      return m_parent.get_param_handle(parname, originator);
     }
     return cci_param_untyped_handle(originator);
   }

--- a/src/cci_utils/broker.h
+++ b/src/cci_utils/broker.h
@@ -25,18 +25,18 @@ namespace cci_utils
     /// for the public broker, this will be useless, but if people re-use this
     /// broker, then it will help
     bool has_parent;
-    cci::cci_broker_handle m_parent;
+    cci::cci_broker_if &m_parent;
 
     // convenience function for constructor
-    cci::cci_broker_handle get_parent_broker(const cci::cci_originator &originator)
+    cci::cci_broker_if &get_parent_broker()
     {
         if (sc_core::sc_get_current_object()) {
             has_parent=true;
-            return cci::cci_get_broker();
+            return unwrap_broker(cci::cci_get_broker());
         } else {
           // We ARE the global broker
           has_parent=false;
-          return cci::cci_broker_handle(*this, originator);
+          return *this;
         }
     }
 

--- a/src/cci_utils/consuming_broker.cpp
+++ b/src/cci_utils/consuming_broker.cpp
@@ -36,8 +36,7 @@ namespace cci_utils {
 // NB this broker must be instanced and registered in the same place
 //
   consuming_broker::consuming_broker(const std::string& name)
-    : m_name(cci_gen_unique_name(name.c_str())),
-    m_originator(cci_originator(m_name))
+    : m_name(cci_gen_unique_name(name.c_str()))
     {
       sc_assert (name.length() > 0 && "Name must not be empty");
     }
@@ -147,11 +146,12 @@ namespace cci_utils {
     locked.insert(parname);
   }
 
-  cci_value consuming_broker::get_cci_value(const std::string &parname) const
+  cci_value consuming_broker::get_cci_value(const std::string &parname,
+  const cci_originator &originator) const
   {
     cci_param_if* p = get_orig_param(parname);
     if(p) {
-      return p->get_cci_value(m_originator);
+      return p->get_cci_value(originator);
     } else {
       std::map<std::string,cci_value>::const_iterator iter =
         m_unused_value_registry.find(parname);

--- a/src/cci_utils/consuming_broker.h
+++ b/src/cci_utils/consuming_broker.h
@@ -63,7 +63,8 @@ public:
       const cci::cci_preset_value_predicate &pred);
 
     /// Get current cci_value
-    cci::cci_value get_cci_value(const std::string &parname) const;
+    cci::cci_value get_cci_value(const std::string &parname,
+        const cci::cci_originator& originator = cci::cci_originator()) const;
     
     /// return a handle with which to access a parameter
     cci::cci_param_untyped_handle get_param_handle(
@@ -109,7 +110,6 @@ public:
     cci::cci_param_if* get_orig_param(const std::string &parname) const;
 
     std::string m_name;
-    const cci::cci_originator m_originator;    
 
     // These are used as a database of _preset_ values.
     std::map<std::string, cci::cci_param_if*> m_param_registry;


### PR DESCRIPTION
The local originator has been removed from the utils brokers. This was the simplest (and cleanest) way to accommodate the new originator construction rules (see #203). Without a local originator (which wasn't really be used anyway) the utils brokers can continue to be instantiated both inside and outside the module hierarchy.

Note: there is no issue with broker implementations having a local originator (this would be needed if they were e.g. processing preset values from a configuration file) - it just keeps things simpler if the utils brokers don't have one.