### PR TITLE
cci_broker_handle: add missing include and const

### DIFF
--- a/src/cci_cfg/cci_broker_handle.h
+++ b/src/cci_cfg/cci_broker_handle.h
@@ -24,6 +24,7 @@
 #include "cci_core/cci_value.h"
 #include "cci_cfg/cci_broker_types.h"
 #include "cci_cfg/cci_originator.h"
+#include "cci_cfg/cci_param_typed_handle.h"
 
 /**
  * @author Guillaume Delbergue, Ericsson / GreenSocs
@@ -138,7 +139,7 @@ public:
      * @return  Parameter handle (invalid if not existing or the type is not correct)
      */
     template<class T>
-    cci_param_typed_handle<T> get_param_handle(const std::string &parname) {
+    cci_param_typed_handle<T> get_param_handle(const std::string &parname) const {
         return cci_param_typed_handle<T>(get_param_handle(parname));
     }
 


### PR DESCRIPTION
In the public review forum, a compiler error on Clang 6.0 has been [reported][1]:

> ```cpp
> cci_broker_handle.h:139:42: error: 
>      calling 'get_param_handle' with incomplete return type 'cci::cci_param_untyped_handle'
>        return cci_param_typed_handle<T>(get_param_handle(parname));
> ```

This PR adds the suggested include.  I agree with the compiler, that the `get_param_handle` function cannot be called while the return type is still incomplete (forward declared in `cci_broker_types.h`).

Along the way, I have added the missing `const` to the templated `get_param_handle` function. All other overloads are marked `const` already.

[1]: http://forums.accellera.org/topic/6037-problem-building-cci-using-clang-60/