### PR TITLE
Remove broker handle originator propagation

### DIFF
--- a/src/cci_cfg/cci_broker_handle.cpp
+++ b/src/cci_cfg/cci_broker_handle.cpp
@@ -176,13 +176,4 @@ bool cci_broker_handle::has_callbacks() const
     return m_broker->has_callbacks();
 }
 
-const cci_originator cci_broker_handle::promote_originator(
-  const cci_originator &gifted_originator)
-{
-    if (sc_core::sc_get_current_object())
-        return cci_originator();
-    else
-        return gifted_originator;
-}
-
 CCI_CLOSE_NAMESPACE_

--- a/src/cci_cfg/cci_broker_handle.h
+++ b/src/cci_cfg/cci_broker_handle.h
@@ -201,7 +201,7 @@ protected:
      * @param gifted_originator associated with the copy ctor broker argument
      * @return context originator if possible; otherwise, the gifted_originator 
      */
-    const cci_originator promote_originator(const cci_originator &gifted_originator);
+    inline const cci_originator promote_originator(const cci_originator &gifted_originator);
 
 private:
     friend class cci_broker_if;
@@ -213,6 +213,17 @@ private:
     cci_broker_if* m_broker;
     cci_originator m_originator;
 };
+
+
+
+const cci_originator cci_broker_handle::promote_originator(
+    const cci_originator &gifted_originator)
+{
+    if (sc_core::sc_get_current_object())
+        return cci_originator();
+    else
+        return gifted_originator;
+}
 
 CCI_CLOSE_NAMESPACE_
 #endif // CCI_CFG_CCI_BROKER_HANDLE_H_INCLUDED_

--- a/src/cci_cfg/cci_param_untyped_handle.cpp
+++ b/src/cci_cfg/cci_param_untyped_handle.cpp
@@ -307,15 +307,6 @@ void cci_param_untyped_handle::check_is_valid() const
     }
 }
 
-const cci_originator cci_param_untyped_handle::promote_originator(
-    const cci_originator &gifted_originator)
-{
-    if (sc_core::sc_get_current_object())
-        return cci_originator();
-    else
-        return gifted_originator;
-}
-
 #undef CCI_PARAM_UNTYPED_HANDLE_CALLBACK_IMPL_
 
 CCI_CLOSE_NAMESPACE_

--- a/src/cci_cfg/cci_param_untyped_handle.h
+++ b/src/cci_cfg/cci_param_untyped_handle.h
@@ -267,7 +267,7 @@ protected:
     * @param gifted_originator associated with the copy ctor broker argument
     * @return context originator if possible; otherwise, the gifted_originator
     */
-    const cci_originator promote_originator(const cci_originator &gifted_originator);
+    inline const cci_originator promote_originator(const cci_originator &gifted_originator);
 
 private:
     cci_param_if*  m_param;
@@ -282,6 +282,16 @@ private:
 
 /// Convenience shortcut for untyped parameter handles
 typedef cci_param_untyped_handle cci_param_handle ;
+
+
+const cci_originator cci_param_untyped_handle::promote_originator(
+    const cci_originator &gifted_originator)
+{
+    if (sc_core::sc_get_current_object())
+        return cci_originator();
+    else
+        return gifted_originator;
+}
 
 CCI_CLOSE_NAMESPACE_
 


### PR DESCRIPTION
Remove originator propagation when assigning broker handles (instead preserve pre-assignment originator in destination broker handle).

For copy construction, set the originator to reflect the current module context when available; otherwise, propagate the source handle's originator (there's nothing else we can do). This change also make to the parameter handle.

Addresses #233.