### PR TITLE
Cleanup interface classes (cci_broker_if, cci_param_if)

### DIFF
--- a/src/cci_cfg/cci_broker_callbacks.h
+++ b/src/cci_cfg/cci_broker_callbacks.h
@@ -1,0 +1,89 @@
+/*****************************************************************************
+
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+
+ ****************************************************************************/
+
+#ifndef CCI_CFG_CCI_BROKER_CALLBACKS_H_INCLUDED_
+#define CCI_CFG_CCI_BROKER_CALLBACKS_H_INCLUDED_
+
+#include "cci_core/cci_callback.h"
+#include "cci_core/cci_value.h"
+
+CCI_OPEN_NAMESPACE_
+
+class cci_param_untyped_handle;
+class cci_originator;
+
+/// Parameter creation callback
+typedef cci_callback<const cci_param_untyped_handle& >
+  cci_param_create_callback;
+
+/// Parameter creation callback handle
+typedef cci_callback_typed_handle<const cci_param_untyped_handle& >
+  cci_param_create_callback_handle;
+
+/// Parameter destruction callback
+typedef cci_callback<const cci_param_untyped_handle& >
+  cci_param_destroy_callback;
+
+/// Parameter destruction callback handle
+typedef cci_callback_typed_handle<const cci_param_untyped_handle& >
+  cci_param_destroy_callback_handle;
+
+/// Parameter predicate
+typedef cci_callback<const cci_param_untyped_handle&, bool >
+        cci_param_predicate;
+
+/// Parameter predicate handle
+typedef cci_callback_typed_handle<const cci_param_untyped_handle&, bool >
+        cci_param_predicate_handle;
+
+/// Preset value predicate
+typedef cci_callback<const std::pair<std::string, cci_value>&, bool >
+        cci_preset_value_predicate;
+
+/// Preset value predicate handle
+typedef cci_callback_typed_handle<const std::pair<std::string, cci_value>&,
+        bool > cci_preset_value_predicate_handle;
+
+/* ------------------------------------------------------------------------ */
+
+/// Callback API of CCI brokers
+struct cci_broker_callback_if
+{
+  virtual cci_param_create_callback_handle
+  register_create_callback( const cci_param_create_callback& cb
+                          , const cci_originator& orig ) = 0;
+  virtual bool
+  unregister_create_callback( const cci_param_create_callback_handle& cb
+                            , const cci_originator& orig ) = 0;
+
+  virtual cci_param_destroy_callback_handle
+  register_destroy_callback( const cci_param_destroy_callback& cb
+                           , const cci_originator& orig ) = 0;
+  virtual bool
+  unregister_destroy_callback( const cci_param_destroy_callback_handle& cb
+                             , const cci_originator& orig ) = 0;
+
+  virtual bool unregister_all_callbacks(const cci_originator& orig) = 0;
+
+  virtual bool has_callbacks() const = 0;
+};
+
+CCI_CLOSE_NAMESPACE_
+
+#endif // CCI_CFG_CCI_BROKER_CALLBACKS_H_INCLUDED_

--- a/src/cci_cfg/cci_broker_if.h
+++ b/src/cci_cfg/cci_broker_if.h
@@ -59,6 +59,7 @@ class cci_broker_handle;
  * @see cci_utils::broker, cci_utils::consuming_broker
  */
 class cci_broker_if
+ : public cci_broker_callback_if
 {
 public:
     friend class cci_broker_handle;
@@ -264,31 +265,6 @@ public:
      * @return If this broker is the global broker
      */
     virtual bool is_global_broker() const = 0;
-
-    ///@name Broker callbacks
-    //@{
-
-    /// Register a callback for parameter creation
-    virtual cci_param_create_callback_handle
-        register_create_callback(const cci_param_create_callback& cb
-            , const cci_originator& orig) = 0;
-    virtual bool
-        unregister_create_callback(const cci_param_create_callback_handle& cb
-            , const cci_originator& orig) = 0;
-
-    /// Register a callback for parameter destruction
-    virtual cci_param_destroy_callback_handle
-        register_destroy_callback(const cci_param_destroy_callback& cb
-            , const cci_originator& orig) = 0;
-    virtual bool
-        unregister_destroy_callback(const cci_param_destroy_callback_handle& cb
-            , const cci_originator& orig) = 0;
-
-    virtual bool unregister_all_callbacks(const cci_originator& orig) = 0;
-
-    /// Return true if any callbacks are currently registered
-    virtual bool has_callbacks() const = 0;
-    //@}
 
 protected:
     /// Default Constructor

--- a/src/cci_cfg/cci_broker_types.h
+++ b/src/cci_cfg/cci_broker_types.h
@@ -22,8 +22,7 @@
 
 #include "cci_core/cci_value.h"
 #include "cci_core/cci_filtered_range.h"
-#include "cci_core/cci_callback.h"
-
+#include "cci_cfg/cci_broker_callbacks.h"
 //
 #include <string>
 #include <utility> // std::pair
@@ -32,38 +31,6 @@ CCI_OPEN_NAMESPACE_
 
 // forward declaration
 class cci_param_untyped_handle;
-
-/// Parameter creation callback
-typedef cci_callback<const cci_param_untyped_handle& >
-cci_param_create_callback;
-
-/// Parameter creation callback handle
-typedef cci_callback_typed_handle<const cci_param_untyped_handle& >
-cci_param_create_callback_handle;
-
-/// Parameter destruction callback
-typedef cci_callback<const cci_param_untyped_handle& >
-cci_param_destroy_callback;
-
-/// Parameter destruction callback handle
-typedef cci_callback_typed_handle<const cci_param_untyped_handle& >
-cci_param_destroy_callback_handle;
-
-/// Parameter predicate
-typedef cci_callback<const cci_param_untyped_handle&, bool >
-cci_param_predicate;
-
-/// Parameter predicate handle
-typedef cci_callback_typed_handle<const cci_param_untyped_handle&, bool >
-cci_param_predicate_handle;
-
-/// Preset value predicate
-typedef cci_callback<const std::pair<std::string, cci_value>&, bool >
-cci_preset_value_predicate;
-
-/// Preset value predicate handle
-typedef cci_callback_typed_handle<const std::pair<std::string, cci_value>&,
-    bool > cci_preset_value_predicate_handle;
 
 /// CCI parameter filter iterator type
 typedef cci_filtered_range<cci_param_untyped_handle, cci_param_predicate>


### PR DESCRIPTION
This PR addresses #242:

- Disable copy constructors and assignment operators for `cci_broker_if` and `cci_param_if`.
- Merge `cci_broker_callback_if` into `cci_broker_if`

We were interested in merging the `cci_param_callback_if` into `cci_param_if` as well but this is not as straightforward so we'll investigate later (after the 1.0 release).