### PR TITLE
rapidjson: Suppress warning on GCC 8

### DIFF
--- a/src/cci_core/rapidjson.h
+++ b/src/cci_core/rapidjson.h
@@ -82,6 +82,9 @@ RAPIDJSON_DIAG_PUSH
 #if __GNUC__ >= 6
 RAPIDJSON_DIAG_OFF( terminate ) // ignore throwing assertions
 #endif
+#if __GNUC__ >= 8
+RAPIDJSON_DIAG_OFF( class-memaccess ) // ignore raw access to class memory
+#endif
 #endif
 
 // throw exception by default


### PR DESCRIPTION
Compiling RapidJSON on GCC 8 gives a new compiler warning. We treat warnings as errors in CCI, causing the CCI build to fail on this compiler.

See Tencent/rapidjson#1246.

This is fixed in the upstream master branch of RapidJSON. We may want to upgrade to a newer RapidJSON version in the future.

In CCI, we can work around this by suppressing the warning for now.