### PR TITLE
Updated NOTICE file to align with systemc.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -6,40 +6,40 @@
  
 This product includes software developed by Accellera Systems Initiative
 8698 Elk Grove Bldv Suite 1, #114, Elk Grove, CA 95624, USA
-Copyright 2009-2018 Accellera Systems Initiative Inc. (Accellera). 
+Copyright 2009-2019 Accellera Systems Initiative Inc. (Accellera). 
 All rights reserved.
 
 This product includes software developed by CircuitSutra Technologies Pvt. Ltd.
 Regus, Ground Floor, Tapasya Corp Heights, Sector 126, Noida, 201303, UP, India
-Copyright 2010-2018 CircuitSutra Technologies Pvt. Ltd. 
+Copyright 2010-2019 CircuitSutra Technologies Pvt. Ltd. 
 All rights reserved.
 
 This product includes software developed by Ericsson AB
 Torshamnsgatan 21, Stockholm, Sweden
-Copyright 2017-2018 Ericsson AB.
+Copyright 2017-2019 Ericsson AB.
 All rights reserved.
 
 This product includes software developed by GreenSocs SAS, 24380 Chalagnac, France,
 on behalf of the IRT Antoine de Saint-Exupery, 3 rue Tarfaya, CS 34436, France
-Copyright 2009-2018 GreenSocs SAS.
+Copyright 2009-2019 GreenSocs SAS.
 All rights reserved.
 
 This product includes software developed by Intel Corp.
 2200 Mission College Blvd., Santa Clara, CA 95054-1549, USA
-Copyright 2009-2018 Intel Corporation.
+Copyright 2009-2019 Intel Corporation.
 All rights reserved.
 
 This product includes software developed by OFFIS eV
 Escherweg 2, 26121 Oldenburg, Germany
-Copyright 2009-2018 OFFIS Institute for Information Technology.
+Copyright 2009-2019 OFFIS Institute for Information Technology.
 All rights reserved.
 
 This product includes software developed by STMicroelectronics International NV
 39, Chemin de Champ-des-Filles, Plan-Les-Ouates, Geneva, Switzerland
-Copyright 2008-2018 STMicroelectronics International NV.
+Copyright 2008-2019 STMicroelectronics International NV.
 All rights reserved.
 
 This product includes software developed by Texas Instruments Inc.
 12500 TI Boulevard, Dallas, TX 75243, USA
-Copyright 2010-2018 Texas Instruments Inc.
+Copyright 2010-2019 Texas Instruments Inc.
 All rights reserved.


### PR DESCRIPTION
Addedd addresses, extended timeframe through 2018 and aligned the format with the systemc NOTICE file. This achieves consistency with https://github.com/OSCI-WG/systemc/pull/305.

Addresses were copied from the systemc NOTICE file for common contributors; publicized addresses were used for [Ericsson ](https://www.ericsson.com/en/contact)and [TI](http://www.ti.com/corp/docs/company/factsheet.shtml).