### PR TITLE
fix for broker has_preset_value

### DIFF
--- a/src/cci/utils/broker.cpp
+++ b/src/cci/utils/broker.cpp
@@ -60,6 +60,15 @@ namespace cci_utils {
     }
   }
   
+  bool broker::has_preset_value(const std::string &parname) const
+  {
+    if (sendToParent(parname)) {
+      return m_parent.has_preset_value(parname);
+    } else {
+      return consuming_broker::has_preset_value(parname);
+    }
+  }
+
   cci_value broker::get_preset_cci_value(const std::string &parname) const
   {
     if (sendToParent(parname)) {

--- a/src/cci/utils/broker.h
+++ b/src/cci/utils/broker.h
@@ -53,6 +53,9 @@ namespace cci_utils
     /// Destructor
     ~broker();
 
+
+    bool has_preset_value(const std::string &parname) const;
+
     /// Return the preset value of a parameter (by name)
     cci::cci_value get_preset_cci_value(const std::string &parname) const;
 


### PR DESCRIPTION
This seems like it's necessary - so here's a patch to fix has_preset_value. See issue #258