### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,15 @@ jobs:
         uses: actions/checkout@v3
       - name: Create configure script
         run: ./config/bootstrap
-      - name: Create output folder
-        run: mkdir output
+      - name: Create output folder and copy files
+        run: |
+          mkdir ${release_name}
+          rsync -av --progress ./ ${release_name} --exclude .git
+          mkdir output
       - name: Create zip
-        run: zip -r output/${release_name}.zip . -x '*.git*' -x '*output*'
+        run: zip -r output/${release_name}.zip ${release_name}
       - name: Create tar
-        working-directory: ./output
-        run: tar -czf ${release_name}.tar.gz --exclude=output --exclude=.git ../*
+        run: tar -cvzf output/${release_name}.tar.gz ${release_name}
       - uses: "marvinpinto/action-automatic-releases@v1.2.1"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Create configure script
-        run: |
-          libtoolize
-          aclocal
-          autoheader
-          autoconf
-          automake --add-missing
+        run: ./config/bootstrap
       - name: Create output folder
         run: mkdir output
       - name: Create zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Create Release
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    env:
+      release_name: ${{ github.event.repository.name }}_${{ github.ref_name }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Create configure script
+        run: |
+          libtoolize
+          aclocal
+          autoheader
+          autoconf
+          automake --add-missing
+      - name: Create output folder
+        run: mkdir output
+      - name: Create zip
+        run: zip -r output/${release_name}.zip . -x '*.git*' -x '*output*'
+      - name: Create tar
+        working-directory: ./output
+        run: tar -czf ${release_name}.tar.gz --exclude=output --exclude=.git ../*
+      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+          title: ${{ github.event.repository.name }} ${{ github.ref_name }}
+          files: output/*


### PR DESCRIPTION
Add action to create a release every time a version tag is created. The version tag needs to start with `v` (e.g., `v1.0.0`). zip and tar.gz files are added to the release that contain the source code and generated configure scripts.

To address #285

---

I certify that the contribution was created in whole by me and I have the right to submit it under the Apache License Version 2.0. I understand and agree that this Accellera project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed in accordance with this project or the Apache License Version 2.0.