### PR TITLE
fixed filename for automake flow

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -30,7 +30,7 @@ examples_FILES = \
 	build-msvc/Makefile \
 	build-msvc/Makefile.config \
 	build-msvc/Makefile.rules \
-	build-msvc/READMEcommandlinemsvc.txt \
+	build-msvc/README.md \
 	build-msvc/cci_examples.props \
 	build-msvc/cci_examples.sln \
 	build-msvc/openhere.bat \


### PR DESCRIPTION
Solves issue reported by @oladahl, https://github.com/accellera-official/cci/pull/279

Filename `READMEcommandlinemsvc.txt` was changed to `README.md` but we forgot to update the reference in the automake flow. This now fixed.

Signed-off-by: Martin Barnasconi <martin.barnasconi@nxp.com>