### PR TITLE
removing file COPYING

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,0 @@
-Copying of this release is governed under the terms of the
-Apache License Version 2.0, a copy of which can be found in
-the LICENSE file distributed with this version of SystemC CCI.
-
-It is also available at:
-http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
To resolve the GitHub message `Apache-2.0, Unknown licenses found`, the COPYING will be removed. This file is not required as part of an Apache-2.0 license library.

Signed-off-by: Martin Barnasconi <martin.barnasconi@nxp.com>