### PR TITLE
Add build actions

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -4,8 +4,7 @@ on: [push, pull_request]
 
 env:
   SYSTEMC_ROOT_HOME: "${{github.workspace}}/systemc"
-  RAPIDJSON_HOME: "${{github.workspace}}/rapidjson"
-  CCI_ROOT_HOME: ${{github.workspace}}/build
+  CCI_ROOT_HOME: "${{github.workspace}}/build"
 
 jobs:
   build:
@@ -96,9 +95,9 @@ jobs:
       env:
         SYSTEMC_URL: "https://github.com/accellera-official/systemc/archive/refs/tags"
       run: |
-        mkdir -p ${SYSTEMC_HOME}
+        mkdir -p ${{env.SYSTEMC_HOME}}
         mkdir -p ${{github.workspace}}/tmp/systemc-${{matrix.systemc_version}} && cd ${{github.workspace}}/tmp/systemc-${{matrix.systemc_version}}
-        wget ${SYSTEMC_URL}/${{matrix.systemc_version}}.tar.gz
+        wget ${{env.SYSTEMC_URL}}/${{matrix.systemc_version}}.tar.gz
         tar -xvf ${{matrix.systemc_version}}.tar.gz
         cd systemc-${{matrix.systemc_version}}
         config/bootstrap
@@ -107,7 +106,7 @@ jobs:
         C=${{matrix.os.c_compiler}} \
         CXXFLAGS="$CXXFLAGS -std=c++11" \
           ../configure \
-            --prefix=${SYSTEMC_HOME} \
+            --prefix=${{env.SYSTEMC_HOME}} \
             --enable-optimize \
             --disable-debug
         make -j ${{env.NPROC}}
@@ -116,27 +115,27 @@ jobs:
     - name: Configure
       run: |
         ./config/bootstrap
-        mkdir -p ${CCI_HOME}/build && cd ${CCI_HOME}/build
+        mkdir -p ${{env.CCI_HOME}}/build && cd ${{env.CCI_HOME}}/build
         CXX=${{matrix.os.cxx_compiler}} \
         C=${{matrix.os.c_compiler}} \
         CXXFLAGS="$CXXFLAGS -std=c++11" \
-        LD_LIBRARY_PATH=${SYSTEMC_HOME}/lib-linux64 \
+        LD_LIBRARY_PATH=${{env.SYSTEMC_HOME}}/lib-linux64 \
           ../../../configure \
-            --prefix=${CCI_HOME} \
+            --prefix=${{env.CCI_HOME}} \
             --enable-optimize \
             --disable-debug \
-            --with-systemc=${SYSTEMC_HOME} \
+            --with-systemc=${{env.SYSTEMC_HOME}} \
             --with-json="/usr"
 
     - name: Build
+      working-directory: ${{env.CCI_HOME}}/build
       run: |
-        cd ${CCI_HOME}/build
         make -j ${{env.NPROC}}
         make install
 
     - name: Test
+      working-directory: ${{env.CCI_HOME}}/build
       run: |
-       cd ${CCI_HOME}/build
        make check
 
     - name: Upload test report

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -10,12 +10,30 @@ env:
 jobs:
   build:
     name: "Build"
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         systemc_version: [2.3.2, 2.3.3, 2.3.4]
-        cxx_compiler: [clang++, g++]
+        os:
+          - name: ubuntu
+            version: 20.04
+            cxx_compiler: g++-9
+            c_compiler: gcc-9
+          - name: ubuntu
+            version: 20.04
+            cxx_compiler: clang++-9
+            c_compiler: clang-9
+            deps: 'clang-9'
+          - name: ubuntu
+            version: 22.04
+            cxx_compiler: g++-11
+            c_compiler: gcc-11
+          - name: ubuntu
+            version: 22.04
+            cxx_compiler: clang++-11
+            c_compiler: clang-11
+            deps: 'clang-11'
+    runs-on: ${{matrix.os.name}}-${{matrix.os.version}}
 
     steps:
     - name: Setup environment vars
@@ -28,19 +46,20 @@ jobs:
       with:
         submodules: 'recursive'
 
-    - name: Setup Dependencies
+    - name: Setup Dependencies Ubuntu
+      if: matrix.os.name == 'ubuntu'
       run: |
         sudo apt-get update -y -qq
         sudo apt-get install -y \
           rapidjson-dev \
-          clang
+          ${{matrix.os.deps}}
 
-    - name: Cache SystemC ${{matrix.systemc_version}} (${{matrix.cxx_compiler}})
+    - name: Cache SystemC ${{matrix.systemc_version}} (${{matrix.os.cxx_compiler}})
       id: cache-SystemC
       uses: actions/cache@v3
       with:
         path: ${{env.SYSTEMC_HOME}}
-        key: ${{runner.os}}-systemc-autotools-${{matrix.systemc_version}}-${{matrix.cxx_compiler}}
+        key: ${{matrix.os.name}}-${{matrix.os.version}}-autotools-systemc-${{matrix.systemc_version}}-${{matrix.os.cxx_compiler}}
 
     - name: Setup SystemC
       if: steps.cache-SystemC.outputs.cache-hit != 'true'
@@ -54,20 +73,22 @@ jobs:
         cd systemc-${{matrix.systemc_version}}
         config/bootstrap
         mkdir build && cd build
-        CXX=${{matrix.cxx_compiler}} \
+        CXX=${{matrix.os.cxx_compiler}} \
+        C=${{matrix.os.c_compiler}} \
         CXXFLAGS="$CXXFLAGS -std=c++11" \
           ../configure \
             --prefix=${SYSTEMC_HOME} \
             --enable-optimize \
             --disable-debug
-        gmake -j`nproc`
-        gmake install
+        make -j`nproc`
+        make install
 
     - name: Configure
       run: |
         ./config/bootstrap
         mkdir -p ${CCI_HOME}/build && cd ${CCI_HOME}/build
-        CXX=${{matrix.cxx_compiler}} \
+        CXX=${{matrix.os.cxx_compiler}} \
+        C=${{matrix.os.c_compiler}} \
         CXXFLAGS="$CXXFLAGS -std=c++11" \
         LD_LIBRARY_PATH=${SYSTEMC_HOME}/lib-linux64 \
           ../../../configure \
@@ -80,17 +101,17 @@ jobs:
     - name: Build
       run: |
         cd ${CCI_HOME}/build
-        gmake -j `nproc`
-        gmake install
+        make -j `nproc`
+        make install
 
     - name: Test
       run: |
        cd ${CCI_HOME}/build
-       gmake check
+       make check
 
     - name: Upload test report
       if: success() || failure()
       uses: actions/upload-artifact@v3
       with:
-        name: test-results-${{matrix.systemc_version}}-${{matrix.cxx_compiler}}
+        name: test-results-${{matrix.systemc_version}}-${{matrix.os.cxx_compiler}}
         path: ${{env.CCI_HOME}}/build/examples/cci/test-suite.log

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -33,6 +33,26 @@ jobs:
             cxx_compiler: clang++-11
             c_compiler: clang-11
             deps: 'clang-11'
+          - name: macos
+            version: 11
+            cxx_compiler: g++
+            c_compiler: gcc
+            deps: 'automake'
+          - name: macos
+            version: 11
+            cxx_compiler: clang++
+            c_compiler: clang
+            deps: 'automake'
+          - name: macos
+            version: 12
+            cxx_compiler: g++
+            c_compiler: gcc
+            deps: 'automake'
+          - name: macos
+            version: 12
+            cxx_compiler: clang++
+            c_compiler: clang
+            deps: 'automake'
     runs-on: ${{matrix.os.name}}-${{matrix.os.version}}
 
     steps:
@@ -40,6 +60,7 @@ jobs:
       run: |
         echo "SYSTEMC_HOME=${SYSTEMC_ROOT_HOME}/${{matrix.systemc_version}}" >> ${GITHUB_ENV}
         echo "CCI_HOME=${CCI_ROOT_HOME}/release-sc_${{matrix.systemc_version}}" >> ${GITHUB_ENV}
+        echo "NPROC=1" >> ${GITHUB_ENV}
 
     - name: Checkout
       uses: actions/checkout@v3
@@ -49,9 +70,18 @@ jobs:
     - name: Setup Dependencies Ubuntu
       if: matrix.os.name == 'ubuntu'
       run: |
+        echo "NPROC=$(nproc)" >> ${GITHUB_ENV}
         sudo apt-get update -y -qq
         sudo apt-get install -y \
           rapidjson-dev \
+          ${{matrix.os.deps}}
+
+    - name: Setup Dependencies MacOS
+      if: matrix.os.name == 'macos'
+      run: |
+        echo "NPROC=$(sysctl -n hw.logicalcpu)" >> ${GITHUB_ENV}
+        brew install \
+          rapidjson \
           ${{matrix.os.deps}}
 
     - name: Cache SystemC ${{matrix.systemc_version}} (${{matrix.os.cxx_compiler}})
@@ -80,7 +110,7 @@ jobs:
             --prefix=${SYSTEMC_HOME} \
             --enable-optimize \
             --disable-debug
-        make -j`nproc`
+        make -j ${{env.NPROC}}
         make install
 
     - name: Configure
@@ -101,7 +131,7 @@ jobs:
     - name: Build
       run: |
         cd ${CCI_HOME}/build
-        make -j `nproc`
+        make -j ${{env.NPROC}}
         make install
 
     - name: Test

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -1,0 +1,96 @@
+name: autotools
+
+on: [push, pull_request]
+
+env:
+  SYSTEMC_ROOT_HOME: "${{github.workspace}}/systemc"
+  RAPIDJSON_HOME: "${{github.workspace}}/rapidjson"
+  CCI_ROOT_HOME: ${{github.workspace}}/build
+
+jobs:
+  build:
+    name: "Build"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        systemc_version: [2.3.2, 2.3.3, 2.3.4]
+        cxx_compiler: [clang++, g++]
+
+    steps:
+    - name: Setup environment vars
+      run: |
+        echo "SYSTEMC_HOME=${SYSTEMC_ROOT_HOME}/${{matrix.systemc_version}}" >> ${GITHUB_ENV}
+        echo "CCI_HOME=${CCI_ROOT_HOME}/release-sc_${{matrix.systemc_version}}" >> ${GITHUB_ENV}
+
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+
+    - name: Setup Dependencies
+      run: |
+        sudo apt-get update -y -qq
+        sudo apt-get install -y \
+          rapidjson-dev \
+          clang
+
+    - name: Cache SystemC ${{matrix.systemc_version}} (${{matrix.cxx_compiler}})
+      id: cache-SystemC
+      uses: actions/cache@v3
+      with:
+        path: ${{env.SYSTEMC_HOME}}
+        key: ${{runner.os}}-systemc-autotools-${{matrix.systemc_version}}-${{matrix.cxx_compiler}}
+
+    - name: Setup SystemC
+      if: steps.cache-SystemC.outputs.cache-hit != 'true'
+      env:
+        SYSTEMC_URL: "https://github.com/accellera-official/systemc/archive/refs/tags"
+      run: |
+        mkdir -p ${SYSTEMC_HOME}
+        mkdir -p ${{github.workspace}}/tmp/systemc-${{matrix.systemc_version}} && cd ${{github.workspace}}/tmp/systemc-${{matrix.systemc_version}}
+        wget ${SYSTEMC_URL}/${{matrix.systemc_version}}.tar.gz
+        tar -xvf ${{matrix.systemc_version}}.tar.gz
+        cd systemc-${{matrix.systemc_version}}
+        config/bootstrap
+        mkdir build && cd build
+        CXX=${{matrix.cxx_compiler}} \
+        CXXFLAGS="$CXXFLAGS -std=c++11" \
+          ../configure \
+            --prefix=${SYSTEMC_HOME} \
+            --enable-optimize \
+            --disable-debug
+        gmake -j`nproc`
+        gmake install
+
+    - name: Configure
+      run: |
+        ./config/bootstrap
+        mkdir -p ${CCI_HOME}/build && cd ${CCI_HOME}/build
+        CXX=${{matrix.cxx_compiler}} \
+        CXXFLAGS="$CXXFLAGS -std=c++11" \
+        LD_LIBRARY_PATH=${SYSTEMC_HOME}/lib-linux64 \
+          ../../../configure \
+            --prefix=${CCI_HOME} \
+            --enable-optimize \
+            --disable-debug \
+            --with-systemc=${SYSTEMC_HOME} \
+            --with-json="/usr"
+
+    - name: Build
+      run: |
+        cd ${CCI_HOME}/build
+        gmake -j `nproc`
+        gmake install
+
+    - name: Test
+      run: |
+       cd ${CCI_HOME}/build
+       gmake check
+
+    - name: Upload test report
+      if: success() || failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-results-${{matrix.systemc_version}}-${{matrix.cxx_compiler}}
+        path: ${{env.CCI_HOME}}/build/examples/cci/test-suite.log

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,85 @@
+name: cmake
+
+on: [push, pull_request]
+
+env:
+  SYSTEMC_ROOT_HOME: "${{github.workspace}}/systemc"
+  RAPIDJSON_HOME: "${{github.workspace}}/rapidjson"
+  CCI_ROOT_HOME: ${{github.workspace}}/build
+
+jobs:
+  build:
+    name: "Build"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        systemc_version: [2.3.2, 2.3.3, 2.3.4]
+        cxx_compiler: [clang++, g++]
+
+    steps:
+    - name: Setup environment vars
+      run: |
+        echo "SYSTEMC_HOME=${SYSTEMC_ROOT_HOME}/${{matrix.systemc_version}}" >> ${GITHUB_ENV}
+        echo "CCI_HOME=${CCI_ROOT_HOME}/release-sc_${{matrix.systemc_version}}" >> ${GITHUB_ENV}
+
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+
+    - name: Setup Dependencies
+      run: |
+        sudo apt-get update -y -qq
+        sudo apt-get install -y \
+          rapidjson-dev \
+          clang
+
+    - name: Cache SystemC ${{matrix.systemc_version}} (${{matrix.cxx_compiler}})
+      id: cache-SystemC
+      uses: actions/cache@v3
+      with:
+        path: ${{env.SYSTEMC_HOME}}
+        key: ${{runner.os}}-systemc-cmake-${{matrix.systemc_version}}-${{matrix.cxx_compiler}}
+
+    - name: Setup SystemC
+      if: steps.cache-SystemC.outputs.cache-hit != 'true'
+      env:
+        SYSTEMC_URL: "https://github.com/accellera-official/systemc/archive/refs/tags"
+      run: |
+        mkdir -p ${SYSTEMC_HOME}
+        mkdir -p ${{github.workspace}}/tmp/systemc-${{matrix.systemc_version}} && cd ${{github.workspace}}/tmp/systemc-${{matrix.systemc_version}}
+        wget ${SYSTEMC_URL}/${{matrix.systemc_version}}.tar.gz
+        tar -xvf ${{matrix.systemc_version}}.tar.gz
+        cd systemc-${{matrix.systemc_version}}
+        mkdir build && cd build
+        cmake  \
+          -DCMAKE_CXX_COMPILER=${{matrix.cxx_compiler}} \
+          -DCMAKE_CXX_STANDARD=11 \
+          -DCMAKE_INSTALL_PREFIX=${SYSTEMC_HOME} \
+          -DCMAKE_BUILD_TYPE=Release \
+          ..
+        gmake -j`nproc`
+        gmake install
+
+    - name: Configure
+      run: |
+        mkdir -p ${CCI_HOME}/build && cd ${CCI_HOME}/build
+        cmake \
+          -DCMAKE_CXX_COMPILER=${{matrix.cxx_compiler}} \
+          -DCMAKE_CXX_STANDARD=11 \
+          -DCMAKE_PREFIX_PATH=${SYSTEMC_HOME}/lib/cmake/SystemCLanguage \
+          -DCMAKE_INSTALL_PREFIX=${CCI_HOME} \
+          -DCMAKE_BUILD_TYPE=Release \
+          ../../..
+
+    - name: Build
+      run: |
+        cd ${CCI_HOME}/build
+        gmake -j `nproc`
+        gmake install
+
+    - name: Test
+      run: |
+       cd ${CCI_HOME}/build
+       gmake check

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,12 +10,30 @@ env:
 jobs:
   build:
     name: "Build"
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         systemc_version: [2.3.2, 2.3.3, 2.3.4]
-        cxx_compiler: [clang++, g++]
+        os:
+          - name: ubuntu
+            version: 20.04
+            cxx_compiler: g++-9
+            c_compiler: gcc-9
+          - name: ubuntu
+            version: 20.04
+            cxx_compiler: clang++-9
+            c_compiler: clang-9
+            deps: 'clang-9'
+          - name: ubuntu
+            version: 22.04
+            cxx_compiler: g++-11
+            c_compiler: gcc-11
+          - name: ubuntu
+            version: 22.04
+            cxx_compiler: clang++-11
+            c_compiler: clang-11
+            deps: 'clang-11'
+    runs-on: ${{matrix.os.name}}-${{matrix.os.version}}
 
     steps:
     - name: Setup environment vars
@@ -28,19 +46,20 @@ jobs:
       with:
         submodules: 'recursive'
 
-    - name: Setup Dependencies
+    - name: Setup Dependencies Ubuntu
+      if: matrix.os.name == 'ubuntu'
       run: |
         sudo apt-get update -y -qq
         sudo apt-get install -y \
           rapidjson-dev \
-          clang
+          ${{matrix.os.deps}}
 
-    - name: Cache SystemC ${{matrix.systemc_version}} (${{matrix.cxx_compiler}})
+    - name: Cache SystemC ${{matrix.systemc_version}} (${{matrix.os.cxx_compiler}})
       id: cache-SystemC
       uses: actions/cache@v3
       with:
         path: ${{env.SYSTEMC_HOME}}
-        key: ${{runner.os}}-systemc-cmake-${{matrix.systemc_version}}-${{matrix.cxx_compiler}}
+        key: ${{matrix.os.name}}-${{matrix.os.version}}-cmake-systemc-${{matrix.systemc_version}}-${{matrix.os.cxx_compiler}}
 
     - name: Setup SystemC
       if: steps.cache-SystemC.outputs.cache-hit != 'true'
@@ -54,19 +73,21 @@ jobs:
         cd systemc-${{matrix.systemc_version}}
         mkdir build && cd build
         cmake  \
-          -DCMAKE_CXX_COMPILER=${{matrix.cxx_compiler}} \
+          -DCMAKE_CXX_COMPILER=${{matrix.os.cxx_compiler}} \
+          -DCMAKE_C_COMPILER=${{matrix.os.c_compiler}} \
           -DCMAKE_CXX_STANDARD=11 \
           -DCMAKE_INSTALL_PREFIX=${SYSTEMC_HOME} \
           -DCMAKE_BUILD_TYPE=Release \
           ..
-        gmake -j`nproc`
-        gmake install
+        make -j`nproc`
+        make install
 
     - name: Configure
       run: |
         mkdir -p ${CCI_HOME}/build && cd ${CCI_HOME}/build
         cmake \
-          -DCMAKE_CXX_COMPILER=${{matrix.cxx_compiler}} \
+          -DCMAKE_CXX_COMPILER=${{matrix.os.cxx_compiler}} \
+          -DCMAKE_C_COMPILER=${{matrix.os.c_compiler}} \
           -DCMAKE_CXX_STANDARD=11 \
           -DCMAKE_PREFIX_PATH=${SYSTEMC_HOME}/lib/cmake/SystemCLanguage \
           -DCMAKE_INSTALL_PREFIX=${CCI_HOME} \
@@ -76,10 +97,10 @@ jobs:
     - name: Build
       run: |
         cd ${CCI_HOME}/build
-        gmake -j `nproc`
-        gmake install
+        make -j `nproc`
+        make install
 
     - name: Test
       run: |
        cd ${CCI_HOME}/build
-       gmake check
+       make check

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -33,6 +33,22 @@ jobs:
             cxx_compiler: clang++-11
             c_compiler: clang-11
             deps: 'clang-11'
+          - name: macos
+            version: 11
+            cxx_compiler: g++
+            c_compiler: gcc
+          - name: macos
+            version: 11
+            cxx_compiler: clang++
+            c_compiler: clang
+          - name: macos
+            version: 12
+            cxx_compiler: g++
+            c_compiler: gcc
+          - name: macos
+            version: 12
+            cxx_compiler: clang++
+            c_compiler: clang
     runs-on: ${{matrix.os.name}}-${{matrix.os.version}}
 
     steps:
@@ -40,6 +56,7 @@ jobs:
       run: |
         echo "SYSTEMC_HOME=${SYSTEMC_ROOT_HOME}/${{matrix.systemc_version}}" >> ${GITHUB_ENV}
         echo "CCI_HOME=${CCI_ROOT_HOME}/release-sc_${{matrix.systemc_version}}" >> ${GITHUB_ENV}
+        echo "NPROC=1" >> ${GITHUB_ENV}
 
     - name: Checkout
       uses: actions/checkout@v3
@@ -49,9 +66,18 @@ jobs:
     - name: Setup Dependencies Ubuntu
       if: matrix.os.name == 'ubuntu'
       run: |
+        echo "NPROC=$(nproc)" >> ${GITHUB_ENV}
         sudo apt-get update -y -qq
         sudo apt-get install -y \
           rapidjson-dev \
+          ${{matrix.os.deps}}
+
+    - name: Setup Dependencies MacOS
+      if: matrix.os.name == 'macos'
+      run: |
+        echo "NPROC=$(sysctl -n hw.logicalcpu)" >> ${GITHUB_ENV}
+        brew install \
+          rapidjson \
           ${{matrix.os.deps}}
 
     - name: Cache SystemC ${{matrix.systemc_version}} (${{matrix.os.cxx_compiler}})
@@ -79,7 +105,7 @@ jobs:
           -DCMAKE_INSTALL_PREFIX=${SYSTEMC_HOME} \
           -DCMAKE_BUILD_TYPE=Release \
           ..
-        make -j`nproc`
+        make -j ${{env.NPROC}}
         make install
 
     - name: Configure
@@ -97,7 +123,7 @@ jobs:
     - name: Build
       run: |
         cd ${CCI_HOME}/build
-        make -j `nproc`
+        make -j ${{env.NPROC}}
         make install
 
     - name: Test

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -4,8 +4,8 @@ on: [push, pull_request]
 
 env:
   SYSTEMC_ROOT_HOME: "${{github.workspace}}/systemc"
-  RAPIDJSON_HOME: "${{github.workspace}}/rapidjson"
-  CCI_ROOT_HOME: ${{github.workspace}}/build
+  CCI_ROOT_HOME: "${{github.workspace}}/build"
+  ESC: '\'
 
 jobs:
   build:
@@ -19,44 +19,91 @@ jobs:
             version: 20.04
             cxx_compiler: g++-9
             c_compiler: gcc-9
+            generator: "Unix Makefiles"
           - name: ubuntu
             version: 20.04
             cxx_compiler: clang++-9
             c_compiler: clang-9
+            generator: "Unix Makefiles"
             deps: 'clang-9'
           - name: ubuntu
             version: 22.04
             cxx_compiler: g++-11
             c_compiler: gcc-11
+            generator: "Unix Makefiles"
           - name: ubuntu
             version: 22.04
             cxx_compiler: clang++-11
             c_compiler: clang-11
+            generator: "Unix Makefiles"
             deps: 'clang-11'
           - name: macos
             version: 11
             cxx_compiler: g++
             c_compiler: gcc
+            generator: "Unix Makefiles"
           - name: macos
             version: 11
             cxx_compiler: clang++
             c_compiler: clang
+            generator: "Unix Makefiles"
           - name: macos
             version: 12
             cxx_compiler: g++
             c_compiler: gcc
+            generator: "Unix Makefiles"
           - name: macos
             version: 12
             cxx_compiler: clang++
             c_compiler: clang
+            generator: "Unix Makefiles"
+          - name: windows
+            version: 2019
+            cxx_compiler: clang++
+            c_compiler: clang
+            generator: "Unix Makefiles"
+          - name: windows
+            version: 2019
+            cxx_compiler: g++
+            c_compiler: gcc
+            generator: "Unix Makefiles"
+          - name: windows
+            version: 2019
+            cxx_compiler: msvc
+            c_compiler: msvc
+            generator: "Visual Studio 16 2019"
+          - name: windows
+            version: 2022
+            cxx_compiler: clang++
+            c_compiler: clang
+            generator: "Unix Makefiles"
+          - name: windows
+            version: 2022
+            cxx_compiler: g++
+            c_compiler: gcc
+            generator: "Unix Makefiles"
+          - name: windows
+            version: 2022
+            cxx_compiler: msvc
+            c_compiler: msvc
+            generator: "Visual Studio 17 2022"
     runs-on: ${{matrix.os.name}}-${{matrix.os.version}}
 
     steps:
     - name: Setup environment vars
+      if: matrix.os.name != 'windows'
       run: |
         echo "SYSTEMC_HOME=${SYSTEMC_ROOT_HOME}/${{matrix.systemc_version}}" >> ${GITHUB_ENV}
         echo "CCI_HOME=${CCI_ROOT_HOME}/release-sc_${{matrix.systemc_version}}" >> ${GITHUB_ENV}
         echo "NPROC=1" >> ${GITHUB_ENV}
+
+    - name: Setup environment vars (Windows)
+      if: matrix.os.name == 'windows'
+      run: |
+        echo "SYSTEMC_HOME=${env:SYSTEMC_ROOT_HOME}/${{matrix.systemc_version}}" | Out-File -FilePath ${env:GITHUB_ENV} -Append 
+        echo "CCI_HOME=${env:CCI_ROOT_HOME}/release-sc_${{matrix.systemc_version}}" | Out-File -FilePath ${env:GITHUB_ENV} -Append 
+        echo "NPROC=${env:NUMBER_OF_PROCESSORS}" | Out-File -FilePath ${env:GITHUB_ENV} -Append 
+        echo "ESC=``" | Out-File -FilePath ${env:GITHUB_ENV} -Append 
 
     - name: Checkout
       uses: actions/checkout@v3
@@ -80,6 +127,23 @@ jobs:
           rapidjson \
           ${{matrix.os.deps}}
 
+    - name: Setup Dependencies Windows
+      if: matrix.os.name == 'windows'
+      run: |
+        # add mingw to path to find clang
+        echo "C:\msys64\mingw64\bin" >> ${GITHUB_PATH}
+
+        choco install wget ${{matrix.os.deps}}
+    
+        git clone https://github.com/Tencent/rapidjson.git ${{github.workspace}}/rapidjson
+        cd ${{github.workspace}}/rapidjson
+        git checkout v1.1.0
+        mkdir build
+        cd build
+        cmake ..
+        cmake --build . -- -j ${{env.NPROC}}
+        cmake --build . --target install
+
     - name: Cache SystemC ${{matrix.systemc_version}} (${{matrix.os.cxx_compiler}})
       id: cache-SystemC
       uses: actions/cache@v3
@@ -92,41 +156,47 @@ jobs:
       env:
         SYSTEMC_URL: "https://github.com/accellera-official/systemc/archive/refs/tags"
       run: |
-        mkdir -p ${SYSTEMC_HOME}
-        mkdir -p ${{github.workspace}}/tmp/systemc-${{matrix.systemc_version}} && cd ${{github.workspace}}/tmp/systemc-${{matrix.systemc_version}}
-        wget ${SYSTEMC_URL}/${{matrix.systemc_version}}.tar.gz
+        mkdir -p ${{env.SYSTEMC_HOME}}
+        mkdir -p ${{github.workspace}}/tmp/systemc-${{matrix.systemc_version}}
+        cd ${{github.workspace}}/tmp/systemc-${{matrix.systemc_version}}
+        wget ${{env.SYSTEMC_URL}}/${{matrix.systemc_version}}.tar.gz
         tar -xvf ${{matrix.systemc_version}}.tar.gz
         cd systemc-${{matrix.systemc_version}}
-        mkdir build && cd build
-        cmake  \
-          -DCMAKE_CXX_COMPILER=${{matrix.os.cxx_compiler}} \
-          -DCMAKE_C_COMPILER=${{matrix.os.c_compiler}} \
-          -DCMAKE_CXX_STANDARD=11 \
-          -DCMAKE_INSTALL_PREFIX=${SYSTEMC_HOME} \
-          -DCMAKE_BUILD_TYPE=Release \
+        mkdir build
+        cd build
+        cmake ${{env.ESC}}
+          -G "${{matrix.os.generator}}" ${{env.ESC}}
+          -DCMAKE_CXX_COMPILER=${{matrix.os.cxx_compiler}} ${{env.ESC}}
+          -DCMAKE_C_COMPILER=${{matrix.os.c_compiler}} ${{env.ESC}}
+          -DCMAKE_CXX_STANDARD=11 ${{env.ESC}}
+          -DCMAKE_INSTALL_PREFIX=${{env.SYSTEMC_HOME}} ${{env.ESC}}
+          -DCMAKE_BUILD_TYPE=Release ${{env.ESC}}
           ..
-        make -j ${{env.NPROC}}
-        make install
+        cmake --build . -- -j ${{env.NPROC}}
+        cmake --build . --target install
 
     - name: Configure
       run: |
-        mkdir -p ${CCI_HOME}/build && cd ${CCI_HOME}/build
-        cmake \
-          -DCMAKE_CXX_COMPILER=${{matrix.os.cxx_compiler}} \
-          -DCMAKE_C_COMPILER=${{matrix.os.c_compiler}} \
-          -DCMAKE_CXX_STANDARD=11 \
-          -DCMAKE_PREFIX_PATH=${SYSTEMC_HOME}/lib/cmake/SystemCLanguage \
-          -DCMAKE_INSTALL_PREFIX=${CCI_HOME} \
-          -DCMAKE_BUILD_TYPE=Release \
+        mkdir -p ${{env.CCI_HOME}}/build
+        cd ${{env.CCI_HOME}}/build
+        cmake ${{env.ESC}}
+          -G "${{matrix.os.generator}}" ${{env.ESC}}
+          -DSYSTEMCCCI_BUILD_TESTS=ON ${{env.ESC}}
+          -DCMAKE_CXX_COMPILER=${{matrix.os.cxx_compiler}} ${{env.ESC}}
+          -DCMAKE_C_COMPILER=${{matrix.os.c_compiler}} ${{env.ESC}}
+          -DCMAKE_CXX_STANDARD=11 ${{env.ESC}}
+          -DCMAKE_PREFIX_PATH=${{env.SYSTEMC_HOME}}/lib/cmake/SystemCLanguage ${{env.ESC}}
+          -DCMAKE_INSTALL_PREFIX=${{env.CCI_HOME}} ${{env.ESC}}
+          -DCMAKE_BUILD_TYPE=Release ${{env.ESC}}
           ../../..
 
     - name: Build
+      working-directory: ${{env.CCI_HOME}}/build
       run: |
-        cd ${CCI_HOME}/build
-        make -j ${{env.NPROC}}
-        make install
+        cmake --build . -- -j ${{env.NPROC}}
+        cmake --build . --target install
 
     - name: Test
+      working-directory: ${{env.CCI_HOME}}/build
       run: |
-       cd ${CCI_HOME}/build
-       make check
+        cmake --build ./examples --target check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,7 +359,7 @@ if (NOT SystemC_TARGET_ARCH)
 endif (NOT SystemC_TARGET_ARCH)
 
 
-set (CMAKE_PREFIX_PATH /opt/systemc)
+list (APPEND CMAKE_PREFIX_PATH /opt/systemc)
 
 IF (NOT SystemCLanguage_FOUND )
     find_package(SystemCLanguage CONFIG REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,7 +106,7 @@ set (CMAKE_CXX_STANDARD_REQUIRED ${SystemC_CXX_STANDARD_REQUIRED} CACHE BOOL
 
 find_package(RapidJSON CONFIG REQUIRED)
 
-target_link_libraries(cci SystemC::systemc rapidjson)
+target_link_libraries(cci SystemC::systemc)
 
 
 add_library (SystemC::cci ALIAS cci)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,7 +135,9 @@ target_compile_options(
 target_include_directories(cci
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  PRIVATE
+  ${RAPIDJSON_INCLUDE_DIRS})
 
 if (APPLE)
   # It's OK that _sc_main is an undefined symbol.


### PR DESCRIPTION
I added GitHub actions to build and test the project using the cmake and autotools workflows. The actions are triggered when new commits are pushed or a pull request is opened.

When I created the actions, I noticed some issues with the cmake workflow. I installed SystemC in a non-default location. In the CMakeLists.txt file, the `CMAKE_PREFIX_PATH` was set to `/opt/systemc`. Since I installed SystemC in another location, my SystemC version was not found. I was not able to specify my SystemC install location during configuration using `cmake -DCMAKE_PREFIX_PATH=/path/to/my/systemc/installation ...` because the value was overwritten by the CMakeLists.txt file. Therefore, I changed the CMakeLists.txt file to append the standard path `/opt/systemc` to the `CMAKE_PREFIX_PATH` variable to still enable a definition during configuration.
Another problem was that it was specified to link cci against rapidjson. Since rapidjson is a header-only library, `librapidjson` was not found and the build failed. I removed the command to link against rapidjson.

The actions build and test cci using different versions of SystemC. I think cmake support of SystemC was added in SystemC 2.3.2, so I just tested SystemC versions 2.3.2 and newer in the cmake workflow. For older SystemC versions, SystemC is not found by cmake due to missing configuration files.
For the autotools workflow, the used compiler was too new to build SystemC 2.3.0a. I got the error 

> "sorry...compiler not supported"

 when I tried to build SystemC. Therefore, I test with SystemC 2.3.1a and newer for the autotools workflow.

When SystemC 2.3.1a is used, the test `ex06_Parameter_Naming` fails with the following output:

>         SystemC 2.3.1-Accellera --- Jan 19 2023 17:28:41
>         Copyright (c) 1996-2014 by all Contributors,
>         ALL RIGHTS RESERVED
> 
> Warning: /Accellera/CCI/cci_name_gen/gen_unique_name: sim_ip.sub_ip is already used in the SystemC hierarchy, using sim_ip.sub_ip_0 instead
> In file: ../../../../../src/cci/core/cci_name_gen.cpp:82
> 
> Fatal: (F4) assertion failed: new_element && "The same parameter had been added twice!!"
> In file: ../../../../../src/cci/utils/consuming_broker.cpp:311
> FAIL ex06_Parameter_Naming/test (exit status: 134)

I am not sure if this is a bug of SystemC or cci. Either the test needs to be fixed or SystemC 2.3.1a should be removed from the tested SystemC versions.

