### PR TITLE
enforce msvc testing on release configuration

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -170,10 +170,9 @@ jobs:
           -DCMAKE_C_COMPILER=${{matrix.os.c_compiler}} ${{env.ESC}}
           -DCMAKE_CXX_STANDARD=11 ${{env.ESC}}
           -DCMAKE_INSTALL_PREFIX=${{env.SYSTEMC_HOME}} ${{env.ESC}}
-          -DCMAKE_BUILD_TYPE=Release ${{env.ESC}}
           ..
-        cmake --build . -- -j ${{env.NPROC}}
-        cmake --build . --target install
+        cmake --build . --config Release -- -j ${{env.NPROC}}
+        cmake --build . --config Release --target install
 
     - name: Configure
       run: |
@@ -187,16 +186,15 @@ jobs:
           -DCMAKE_CXX_STANDARD=11 ${{env.ESC}}
           -DCMAKE_PREFIX_PATH=${{env.SYSTEMC_HOME}}/lib/cmake/SystemCLanguage ${{env.ESC}}
           -DCMAKE_INSTALL_PREFIX=${{env.CCI_HOME}} ${{env.ESC}}
-          -DCMAKE_BUILD_TYPE=Release ${{env.ESC}}
           ../../..
 
     - name: Build
       working-directory: ${{env.CCI_HOME}}/build
       run: |
-        cmake --build . -- -j ${{env.NPROC}}
-        cmake --build . --target install
+        cmake --build . --config Release -- -j ${{env.NPROC}}
+        cmake --build . --config Release --target install
 
     - name: Test
       working-directory: ${{env.CCI_HOME}}/build
       run: |
-        cmake --build ./examples --target check
+        cmake --build ./examples --config Release --target check


### PR DESCRIPTION
according to [this](https://stackoverflow.com/questions/24460486/cmake-build-type-is-not-being-used-in-cmakelists-txt), the use of a Visual Studio generator (-G) will ignore the flag `CMAKE_BUILD_TYPE`. So instead the option `--config Release` has been added to the build.