### PR TITLE
Update cci_version.h in preparation for 1.0.1 release

### DIFF
--- a/src/cci/core/cci_version.h
+++ b/src/cci/core/cci_version.h
@@ -26,12 +26,12 @@
 #ifndef CCI_CORE_CCI_VERSION_H_INCLUDED_
 #define CCI_CORE_CCI_VERSION_H_INCLUDED_
 
-#define CCI_SHORT_RELEASE_DATE 20180613
+#define CCI_SHORT_RELEASE_DATE 20230909
 
 #define CCI_VERSION_ORIGINATOR "Accellera"
 #define CCI_VERSION_MAJOR      1
 #define CCI_VERSION_MINOR      0
-#define CCI_VERSION_PATCH      0
+#define CCI_VERSION_PATCH      1
 #define CCI_IS_PRERELEASE      0
 
 // token stringification


### PR DESCRIPTION
I think this is a required change before we can tag 1.0.1, right?