### PR TITLE
Remove override for INSTALL_NAME_DIR as the default behaviour is expected

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,7 +148,7 @@ set_target_properties (cci
                        LINKER_LANGUAGE CXX
                        VERSION ${SystemCCCI_VERSION}
                        SOVERSION ${SystemCCCI_SOVERSION}
-                       INSTALL_NAME_DIR ${CMAKE_INSTALL_FULL_LIBDIR})
+                       )
 
 
 ###############################################################################


### PR DESCRIPTION
Here is about the most trivial test case I think we could come up with - only for SystemC, but CCI suffers the same issue.
CMakeLIsts.txt:
``` cmake
cmake_minimum_required(VERSION 3.19)
project(test VERSION 1.0)
include(FetchContent)

FetchContent_Declare(
    cpm-cmake
    GIT_REPOSITORY https://github.com/cpm-cmake/CPM.cmake.git
    GIT_TAG v0.31.1)
FetchContent_MakeAvailable(cpm-cmake)
include(${cpm-cmake_SOURCE_DIR}/cmake/CPM.cmake)

# this one is good for building a moden package
cpmaddpackage("gh:TheLartians/PackageProject.cmake@1.4.1")
CPMAddPackage("gh:fmtlib/fmt#7.1.3")

cpmaddpackage(
    NAME SystemCLanguage
    GIT_REPOSITORY https://github.com/accellera-official/systemc.git
    GIT_TAG main
)
add_executable(test test.cc)
target_link_libraries(test PUBLIC SystemC::systemc fmt::fmt)

install (TARGETS test DESTINATION ${CMAKE_INSTALL_BINDIR})

```
test.cc:
``` c++
#include <systemc.h>

int sc_main(int argc, char* argv[])
{

    /* empty */
}
```

If you build this (on a Mac) along the lines of:
``` sh
cmake -B build -DCMAKE_INSTALL_PREFIX=`pwd`/install
cd build
make
make install
```

Then use 
``` sh
otool -l install/bin/test
```


In the middle you’ll see

```
Load command 14
          cmd LC_LOAD_DYLIB
      cmdsize 88
         name /Users/mburton/work/test/install/lib/libsystemc.3.0.dylib (offset 24)
   time stamp 2 Thu Jan  1 01:00:02 1970
      current version 3.0.0
compatibility version 3.0.0
Load command 15
          cmd LC_LOAD_DYLIB
      cmdsize 48
         name @rpath/libfmt.7.dylib (offset 24)
   time stamp 2 Thu Jan  1 01:00:02 1970
      current version 7.1.3
compatibility version 7.0.0
```

Note how fmt gets the rpath correctly, while systemc takes the absolute path of where it was built :-(
(Even though, it’s installed SystemC in the install path).

IMHO it should do roughly the same as (e.g.) FMT, and use an rpath - allowing the user to set the rpath to include whatever they want (e.g. a relative path to the installed libraries, or an absolute path, or whatever).
