### PR TITLE
ci(macos): Update runner

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,12 +32,12 @@ jobs:
             c_compiler: clang
             generator: "Unix Makefiles"
           - name: macos
-            version: 13
+            version: 15-intel
             cxx_compiler: g++
             c_compiler: gcc
             generator: "Unix Makefiles"
           - name: macos
-            version: 13
+            version: 15-intel
             cxx_compiler: clang++
             c_compiler: clang
             generator: "Unix Makefiles"


### PR DESCRIPTION
The macOS 13 runner will be deprecated soon.
The new ones will be supported until August 27.
After that, GitHub will no longer provide x86-based macOS runners.