### PR TITLE
cci-config: Add root dir to target_include_directories

### DIFF
--- a/configuration/src/CMakeLists.txt
+++ b/configuration/src/CMakeLists.txt
@@ -131,6 +131,7 @@ target_compile_features(
 target_include_directories(cci-config
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 target_include_directories(cci-config


### PR DESCRIPTION
This commits insures that `cci/common/cci_version.h` is correctly exported when the cci is used from the build directory. For example when it's imported as a dependency via CPM.