### PR TITLE
Fix maybe-uninitialized warning

### DIFF
--- a/configuration/src/cci/core/cci_value.h
+++ b/configuration/src/cci/core/cci_value.h
@@ -240,7 +240,7 @@ cci_value_cref::try_get( T& dst ) const
 template<typename T>
 CCI_VALUE_REQUIRES_CONVERTER_(T,T) cci_value_cref::get() const
 {
-  T result;
+  T result = {};
   if( !try_get(result) ) {
     report_error("conversion from cci_value failed", __FILE__, __LINE__);
   }


### PR DESCRIPTION
Fix following warning
```
${cci_src}/cci/cfg/cci_param_typed.h: In member function ‘set_cci_value’:
${cci_src}/cci/cfg/cci_param_typed.h:760: error: ‘result’ may be used uninitialized [-Werror=maybe-uninitialized]
  760 |     value_type v = val.get<value_type>();
      |
${cci_src}/cci/core/cci_value.h:243: note: ‘result’ was declared here
  243 |   T result;
      |
```