### PR TITLE
Find systemc discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,20 @@ message (STATUS "CMAKE_INSTALL_LIBDIR = ${CMAKE_INSTALL_LIBDIR}")
 message (STATUS "INSTALL_CMAKEDIR = ${INSTALL_CMAKEDIR}")
 message (STATUS "======================================================================================================")
 
+if (DEFINED ENV{SYSTEMC_HOME})
+  list (APPEND CMAKE_PREFIX_PATH $ENV{SYSTEMC_HOME})
+  # Also search platform-specific lib subdirectories (e.g. lib-mingw-w64, lib64)
+  # so that find_package(SystemCLanguage) can locate cmake config files
+  # even when SystemC was installed with a non-default CMAKE_INSTALL_LIBDIR.
+  file (GLOB _sc_libsubdirs LIST_DIRECTORIES true "$ENV{SYSTEMC_HOME}/lib*")
+  foreach (_sc_libsubdir IN LISTS _sc_libsubdirs)
+    if (IS_DIRECTORY "${_sc_libsubdir}")
+      list (APPEND CMAKE_PREFIX_PATH "${_sc_libsubdir}")
+    endif ()
+  endforeach ()
+  unset (_sc_libsubdirs)
+  unset (_sc_libsubdir)
+endif ()
 
 set(CCI_INTERFACE_MEMBERS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,11 +186,10 @@ message (STATUS "CMAKE_INSTALL_LIBDIR = ${CMAKE_INSTALL_LIBDIR}")
 message (STATUS "INSTALL_CMAKEDIR = ${INSTALL_CMAKEDIR}")
 message (STATUS "======================================================================================================")
 
+#If SYSTEMC_HOME is defined add it to the search path for the find_package/find_libary ... 
 if (DEFINED ENV{SYSTEMC_HOME})
   list (APPEND CMAKE_PREFIX_PATH $ENV{SYSTEMC_HOME})
   # Also search platform-specific lib subdirectories (e.g. lib-mingw-w64, lib64)
-  # so that find_package(SystemCLanguage) can locate cmake config files
-  # even when SystemC was installed with a non-default CMAKE_INSTALL_LIBDIR.
   file (GLOB _sc_libsubdirs LIST_DIRECTORIES true "$ENV{SYSTEMC_HOME}/lib*")
   foreach (_sc_libsubdir IN LISTS _sc_libsubdirs)
     if (IS_DIRECTORY "${_sc_libsubdir}")


### PR DESCRIPTION
find_package(SystemCLanguage)  from CCI happens in configuration/CMakeLists.txt (sub-directory) which only hardcodes /opt/systemc this will make cmake look into /opt/systemc/lib/cmake/SystemCLanguage and /opt/systemc/lib64/cmake/SystemCLanguage

It would be nice if cmake would discover SystemC installations by SYSTEMC_HOME. In addition it should still discover it, if custom  CMAKE_INSTALL_LIBDIR was used which is not /lib or /lib64. (e.g. linux64 ...)

The code therefore adds $SYSTEMC_HOME to CMAKE_PREFIX_PATH and the underlying lib dirs 
- Globs all lib* subdirs under SYSTEMC_HOME (catches lib-linux64, lib-mingw-w64, etc.) and adds them too
- This runs before configuration/CMakeLists.txt calls find_package(SystemCLanguage), so the cmake config files will be found regardless of which platform-specific CMAKE_INSTALL_LIBDIR was used when building SystemC.

I'm not a cmake specialist but I'm currently working on cmake for SystemC AMS were needed it as well, feedback is welcome. 

