### PR TITLE
Prefer matching SystemC libdir before lib* fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,8 +186,10 @@ message (STATUS "CMAKE_INSTALL_LIBDIR = ${CMAKE_INSTALL_LIBDIR}")
 message (STATUS "INSTALL_CMAKEDIR = ${INSTALL_CMAKEDIR}")
 message (STATUS "======================================================================================================")
 
-#If SYSTEMC_HOME is defined add it to the search path for the find_package/find_libary ... 
-if (DEFINED ENV{SYSTEMC_HOME})
+# Treat an explicitly selected SystemCLanguage_DIR as authoritative: do not add
+# SYSTEMC_HOME-derived guesses that could hide an invalid user-supplied path.
+# Without an explicit selection, use SYSTEMC_HOME for package/library discovery.
+if (NOT DEFINED SystemCLanguage_DIR AND DEFINED ENV{SYSTEMC_HOME})
     list (APPEND CMAKE_PREFIX_PATH "$ENV{SYSTEMC_HOME}")
 
     # Prefer the libdir matching the current CCI configuration.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,16 +188,29 @@ message (STATUS "===============================================================
 
 #If SYSTEMC_HOME is defined add it to the search path for the find_package/find_libary ... 
 if (DEFINED ENV{SYSTEMC_HOME})
-  list (APPEND CMAKE_PREFIX_PATH $ENV{SYSTEMC_HOME})
-  # Also search platform-specific lib subdirectories (e.g. lib-mingw-w64, lib64)
-  file (GLOB _sc_libsubdirs LIST_DIRECTORIES true "$ENV{SYSTEMC_HOME}/lib*")
-  foreach (_sc_libsubdir IN LISTS _sc_libsubdirs)
-    if (IS_DIRECTORY "${_sc_libsubdir}")
-      list (APPEND CMAKE_PREFIX_PATH "${_sc_libsubdir}")
+    list (APPEND CMAKE_PREFIX_PATH "$ENV{SYSTEMC_HOME}")
+
+    # Prefer the libdir matching the current CCI configuration.
+    if (NOT IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+        set (_sc_preferred_libdir "$ENV{SYSTEMC_HOME}/${CMAKE_INSTALL_LIBDIR}")
+        if (IS_DIRECTORY "${_sc_preferred_libdir}")
+            list (APPEND CMAKE_PREFIX_PATH "${_sc_preferred_libdir}")
+        endif ()
     endif ()
-  endforeach ()
-  unset (_sc_libsubdirs)
-  unset (_sc_libsubdir)
+
+    # Fall back to all available SystemC lib directories.
+    file (GLOB _sc_libsubdirs LIST_DIRECTORIES true "$ENV{SYSTEMC_HOME}/lib*")
+    list (REMOVE_ITEM _sc_libsubdirs "${_sc_preferred_libdir}")
+
+    foreach (_sc_libsubdir IN LISTS _sc_libsubdirs)
+        if (IS_DIRECTORY "${_sc_libsubdir}")
+            list (APPEND CMAKE_PREFIX_PATH "${_sc_libsubdir}")
+        endif ()
+    endforeach ()
+
+    unset (_sc_preferred_libdir)
+    unset (_sc_libsubdirs)
+    unset (_sc_libsubdir)
 endif ()
 
 set(CCI_INTERFACE_MEMBERS)

--- a/configuration/CMakeLists.txt
+++ b/configuration/CMakeLists.txt
@@ -256,11 +256,18 @@ if (NOT SystemC_TARGET_ARCH)
 endif (NOT SystemC_TARGET_ARCH)
 
 
-list (APPEND CMAKE_PREFIX_PATH /opt/systemc)
-
 IF (NOT SystemCLanguage_FOUND AND NOT TARGET SystemC::systemc)
-    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
-    find_package(SystemCLanguage REQUIRED)
+    if (DEFINED SystemCLanguage_DIR)
+      find_package(
+        SystemCLanguage CONFIG REQUIRED
+        PATHS "${SystemCLanguage_DIR}"
+        NO_DEFAULT_PATH
+      )
+    else ()
+      list (APPEND CMAKE_PREFIX_PATH /opt/systemc)
+      list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
+      find_package(SystemCLanguage REQUIRED)
+    endif ()
 ENDIF ()
 message (STATUS "Using SystemC ${SystemCLanguage_VERSION} (${SystemCLanguage_DIR})")
 IF ( "${SystemC_CXX_STANDARD}" AND NOT "${SystemC_CXX_STANDARD}" EQUAL "${CMAKE_CXX_STANDARD}")
@@ -346,5 +353,3 @@ install (FILES AUTHORS
                README.md
          DESTINATION ${CMAKE_INSTALL_DOCDIR}/configuration
          COMPONENT doc)
-
-


### PR DESCRIPTION
PR #347 allows custom SystemC library directories discovery by adding all ${SYSTEMC_HOME}/lib* directories to the search path.

When multiple variants exist within SystemC Home, prefer ${SYSTEMC_HOME}/${CMAKE_INSTALL_LIBDIR} first. This is our best available guess as the user probably uses the CMAKE_INSTALL_LIBDIR for both SystemC and CCI. This avoids relying on glob order for multiple lib* dirs. 

The existing lib* search remains as fallback.